### PR TITLE
Add LambdaAuth for ALB Lambda integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ src/cognito_auth/
 ├── dash.py              # DashAuth
 ├── fastapi.py           # FastAPIAuth
 ├── gradio.py            # GradioAuth
+├── lambda_auth.py       # LambdaAuth (ALB Lambda integration)
 └── exceptions.py        # InvalidTokenError, ExpiredTokenError
 ```
 

--- a/docs/api/lambda-auth.md
+++ b/docs/api/lambda-auth.md
@@ -1,0 +1,130 @@
+# LambdaAuth
+
+Authentication for AWS Lambda functions behind an Application Load Balancer.
+
+::: cognito_auth.lambda_auth.LambdaAuth
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - __init__
+        - get_auth_user
+
+## Quick Start
+
+```python
+from cognito_auth.lambda_auth import LambdaAuth
+from cognito_auth import Authoriser
+
+authoriser = Authoriser.from_lists(allowed_groups=["developers"])
+auth = LambdaAuth(authoriser=authoriser)
+
+def handler(event, context):
+    try:
+        user = auth.get_auth_user(event)
+    except Exception:
+        return {
+            "statusCode": 302,
+            "headers": {"Location": auth.redirect_url},
+            "body": "",
+        }
+
+    return {
+        "statusCode": 200,
+        "body": f"Hello {user.email}!",
+    }
+```
+
+## Configuration
+
+LambdaAuth inherits from BaseAuth and accepts these parameters:
+
+- **`authoriser`** (optional): Pre-configured Authoriser instance. If not provided, auto-loads from environment variables
+- **`redirect_url`** (optional): Where to redirect unauthorised users (default: "https://public.gds-idea.io/401.html"). Available as `auth.redirect_url` for building redirect responses.
+- **`region`** (optional): AWS region (default: "eu-west-2")
+
+```python
+from cognito_auth import Authoriser
+from cognito_auth.lambda_auth import LambdaAuth
+
+# Custom configuration
+authoriser = Authoriser.from_lists(allowed_groups=["developers"])
+auth = LambdaAuth(
+    authoriser=authoriser,
+    redirect_url="https://myapp.com/unauthorised",
+    region="us-east-1"
+)
+```
+
+## Behavior
+
+LambdaAuth extracts OIDC headers from the ALB Lambda event and verifies them. On failure:
+
+- **`MissingTokenError`**: Required OIDC headers not present in the event
+- **`InvalidTokenError`**: Token verification failed
+- **`ExpiredTokenError`**: Token has expired
+- **`PermissionError`**: User authenticated but not authorised
+
+The caller is responsible for building the appropriate Lambda response (redirect, JSON error, etc.).
+
+## Development Mode
+
+Enable dev mode for local development without ALB. See [Development Mode](../dev-mode.md) for full details.
+
+```bash
+export COGNITO_AUTH_DEV_MODE=true
+```
+
+## Complete Example
+
+```python
+from cognito_auth.lambda_auth import LambdaAuth
+from cognito_auth import Authoriser
+
+authoriser = Authoriser.from_lists(allowed_groups=["developers"])
+auth = LambdaAuth(authoriser=authoriser)
+
+def handler(event, context):
+    try:
+        user = auth.get_auth_user(event)
+    except Exception:
+        return {
+            "statusCode": 302,
+            "headers": {"Location": auth.redirect_url},
+            "body": "",
+        }
+
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "text/html"},
+        "body": f"""
+            <h1>Welcome {user.name}!</h1>
+            <p>Email: {user.email}</p>
+            <p>Groups: {', '.join(user.groups)}</p>
+        """,
+    }
+```
+
+### No Authorisation (Authentication Only)
+
+```python
+from cognito_auth.lambda_auth import LambdaAuth
+
+# Pass authoriser=None to skip authorisation checks
+auth = LambdaAuth(authoriser=None)
+
+def handler(event, context):
+    try:
+        user = auth.get_auth_user(event)
+    except Exception:
+        return {
+            "statusCode": 302,
+            "headers": {"Location": auth.redirect_url},
+            "body": "",
+        }
+
+    return {
+        "statusCode": 200,
+        "body": f"Authenticated as {user.email}",
+    }
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,4 +71,5 @@ nav:
       - DashAuth: api/dash-auth.md
       - FastAPIAuth: api/fastapi-auth.md
       - GradioAuth: api/gradio-auth.md
+      - LambdaAuth: api/lambda-auth.md
       - Exceptions: api/exceptions.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-auth"
-version = "0.3.1"
+version = "0.3.2"
 description = "Unified authentication and authorisation for AWS Cognito-protected web applications across multiple frameworks"
 readme = "README.md"
 authors = [

--- a/src/cognito_auth/lambda_auth.py
+++ b/src/cognito_auth/lambda_auth.py
@@ -1,0 +1,96 @@
+"""
+AWS Lambda authentication module.
+"""
+
+import logging
+
+from ._base_auth import BaseAuth
+from .user import User
+
+logger = logging.getLogger(__name__)
+
+
+class LambdaAuth(BaseAuth):
+    """
+    Authentication for AWS Lambda functions behind an ALB.
+
+    Use this when your Lambda function is a target of an Application Load
+    Balancer with OIDC (Cognito) authentication configured. The ALB forwards
+    OIDC headers in the Lambda event, and this class verifies them.
+
+    Example:
+        from cognito_auth.lambda_auth import LambdaAuth
+        from cognito_auth import Authoriser
+
+        authoriser = Authoriser.from_lists(allowed_groups=["developers"])
+        auth = LambdaAuth(authoriser=authoriser)
+
+        def handler(event, context):
+            try:
+                user = auth.get_auth_user(event)
+            except Exception:
+                return {
+                    "statusCode": 302,
+                    "headers": {"Location": auth.redirect_url},
+                    "body": "",
+                }
+
+            return {
+                "statusCode": 200,
+                "body": f"Hello {user.email}!",
+            }
+    """
+
+    def get_auth_user(self, event: dict) -> User:
+        """
+        Get the authenticated and authorised user from an ALB Lambda event.
+
+        Extracts OIDC headers from the event, verifies the tokens, and checks
+        authorisation rules.
+
+        Args:
+            event: ALB Lambda event dictionary. Must contain a "headers" key
+                with the ALB OIDC headers (x-amzn-oidc-data and
+                x-amzn-oidc-accesstoken).
+
+        Returns:
+            Authenticated and authorised User
+
+        Raises:
+            MissingTokenError: If required OIDC headers are not present
+            InvalidTokenError: If token verification fails
+            ExpiredTokenError: If tokens have expired
+            PermissionError: If user is authenticated but not authorised
+
+        Example:
+            auth = LambdaAuth()
+
+            def handler(event, context):
+                try:
+                    user = auth.get_auth_user(event)
+                except Exception:
+                    return {
+                        "statusCode": 302,
+                        "headers": {"Location": auth.redirect_url},
+                        "body": "",
+                    }
+
+                return {
+                    "statusCode": 200,
+                    "body": f"Hello {user.email}!",
+                }
+        """
+        headers = event.get("headers", {})
+        user = self._get_user_from_headers(headers)
+
+        if not self._is_authorised(user):
+            logger.warning(
+                "User not authorised: email=%s, groups=%s",
+                user.email,
+                user.groups,
+            )
+            raise PermissionError(
+                "Access denied. You don't have permission to access this resource."
+            )
+
+        return user

--- a/tests/cognito_auth/test_lambda_auth.py
+++ b/tests/cognito_auth/test_lambda_auth.py
@@ -1,0 +1,174 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from cognito_auth.exceptions import MissingTokenError
+from cognito_auth.lambda_auth import LambdaAuth
+
+
+@pytest.fixture
+def lambda_auth(auth_config_file):
+    """Create LambdaAuth instance with config"""
+    with patch.dict(
+        os.environ, {"COGNITO_AUTH_CONFIG_PATH": str(auth_config_file)}, clear=True
+    ):
+        yield LambdaAuth()
+
+
+@pytest.fixture
+def alb_event():
+    """Create a minimal ALB Lambda event with OIDC headers"""
+    return {
+        "requestContext": {
+            "elb": {
+                "targetGroupArn": (
+                    "arn:aws:elasticloadbalancing"
+                    ":eu-west-2:123456789"
+                    ":targetgroup/test/abc123"
+                )
+            }
+        },
+        "httpMethod": "GET",
+        "path": "/",
+        "queryStringParameters": {},
+        "headers": {
+            "x-amzn-oidc-data": "mock-oidc-token",
+            "x-amzn-oidc-accesstoken": "mock-access-token",
+            "host": "example.com",
+        },
+        "body": "",
+        "isBase64Encoded": False,
+    }
+
+
+# Tests for get_auth_user()
+
+
+def test_get_auth_user_returns_user(lambda_auth, alb_event, mock_user_developer):
+    """get_auth_user returns authenticated and authorised user"""
+    with (
+        patch.object(
+            lambda_auth, "_get_user_from_headers", return_value=mock_user_developer
+        ),
+        patch.object(lambda_auth, "_is_authorised", return_value=True),
+    ):
+        user = lambda_auth.get_auth_user(alb_event)
+
+        assert user == mock_user_developer
+        assert user.email == mock_user_developer.email
+
+
+def test_get_auth_user_passes_headers_to_base(
+    lambda_auth, alb_event, mock_user_developer
+):
+    """get_auth_user extracts headers from event and passes to _get_user_from_headers"""
+    with (
+        patch.object(
+            lambda_auth, "_get_user_from_headers", return_value=mock_user_developer
+        ) as mock_get_user,
+        patch.object(lambda_auth, "_is_authorised", return_value=True),
+    ):
+        lambda_auth.get_auth_user(alb_event)
+
+        mock_get_user.assert_called_once_with(alb_event["headers"])
+
+
+def test_get_auth_user_raises_on_missing_headers(lambda_auth):
+    """get_auth_user raises when OIDC headers are missing"""
+    event = {
+        "headers": {"host": "example.com"},
+    }
+
+    with pytest.raises(MissingTokenError):
+        lambda_auth.get_auth_user(event)
+
+
+def test_get_auth_user_raises_on_empty_event(lambda_auth):
+    """get_auth_user raises when event has no headers key"""
+    event = {}
+
+    with pytest.raises(MissingTokenError):
+        lambda_auth.get_auth_user(event)
+
+
+def test_get_auth_user_raises_permission_error_when_unauthorised(
+    lambda_auth, alb_event, mock_user_other
+):
+    """get_auth_user raises PermissionError when user not authorised"""
+    with (
+        patch.object(
+            lambda_auth, "_get_user_from_headers", return_value=mock_user_other
+        ),
+        patch.object(lambda_auth, "_is_authorised", return_value=False),
+    ):
+        with pytest.raises(PermissionError, match="Access denied"):
+            lambda_auth.get_auth_user(alb_event)
+
+
+def test_get_auth_user_propagates_auth_exception(lambda_auth, alb_event):
+    """get_auth_user propagates exceptions from token verification"""
+    with patch.object(
+        lambda_auth, "_get_user_from_headers", side_effect=Exception("Token invalid")
+    ):
+        with pytest.raises(Exception, match="Token invalid"):
+            lambda_auth.get_auth_user(alb_event)
+
+
+def test_get_auth_user_works_with_real_event_structure(
+    lambda_auth, mock_user_developer
+):
+    """get_auth_user works with a realistic ALB event shape"""
+    event = {
+        "requestContext": {
+            "elb": {
+                "targetGroupArn": (
+                    "arn:aws:elasticloadbalancing"
+                    ":eu-west-2:992382722318"
+                    ":targetgroup/test-proxy/2d8d8e1dd3e26a51"
+                )
+            }
+        },
+        "httpMethod": "GET",
+        "path": "/404.html",
+        "queryStringParameters": {},
+        "headers": {
+            "accept": "text/html",
+            "host": "gds-idea.click",
+            "x-amzn-oidc-accesstoken": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9",
+            "x-amzn-oidc-data": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9",
+            "x-amzn-oidc-identity": "16f2c2a4-0071-70dd-3afa-20777368520f",
+            "x-forwarded-for": "90.254.238.183",
+            "x-forwarded-port": "443",
+            "x-forwarded-proto": "https",
+        },
+        "body": "",
+        "isBase64Encoded": True,
+    }
+
+    with (
+        patch.object(
+            lambda_auth, "_get_user_from_headers", return_value=mock_user_developer
+        ),
+        patch.object(lambda_auth, "_is_authorised", return_value=True),
+    ):
+        user = lambda_auth.get_auth_user(event)
+        assert user == mock_user_developer
+
+
+def test_dev_mode_returns_mock_user(auth_config_file):
+    """Dev mode bypasses authentication and returns mock user"""
+    with patch.dict(
+        os.environ,
+        {
+            "COGNITO_AUTH_DEV_MODE": "true",
+        },
+        clear=True,
+    ):
+        auth = LambdaAuth(authoriser=None)
+        event = {"headers": {}}
+
+        user = auth.get_auth_user(event)
+
+        assert user is not None
+        assert user.email is not None


### PR DESCRIPTION
## Summary

- New `LambdaAuth` class for AWS Lambda functions behind an Application Load Balancer with OIDC (Cognito) authentication
- Extracts OIDC headers from ALB Lambda events, verifies tokens, checks authorisation rules
- Simple API: `get_auth_user(event)` returns a `User` or raises, leaving response handling to the caller

## Usage

```python
from cognito_auth.lambda_auth import LambdaAuth
from cognito_auth import Authoriser

authoriser = Authoriser.from_lists(allowed_groups=["developers"])
auth = LambdaAuth(authoriser=authoriser)

def handler(event, context):
    try:
        user = auth.get_auth_user(event)
    except Exception:
        return {
            "statusCode": 302,
            "headers": {"Location": auth.redirect_url},
            "body": "",
        }

    return {"statusCode": 200, "body": f"Hello {user.email}!"}
```

## Changes

| File | Change |
|------|--------|
| `src/cognito_auth/lambda_auth.py` | New `LambdaAuth(BaseAuth)` class with `get_auth_user(event)` |
| `tests/cognito_auth/test_lambda_auth.py` | 8 tests covering success, missing headers, empty event, unauthorised, exception propagation, real event structure, and dev mode |
| `docs/api/lambda-auth.md` | Full documentation with quick start, configuration, behaviour, and examples |
| `mkdocs.yml` | Added LambdaAuth to nav |
| `AGENTS.md` | Added lambda_auth.py to package structure |
| `pyproject.toml` | Version bump to 0.3.2 |

## Testing

All 159 tests pass (151 existing + 8 new). Linting clean.