### PR TITLE
Add AuthorisedDataFrame for row-level security [df]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ src/cognito_auth/
 ├── token_verifier.py    # JWT verification (ALB ES256, Cognito RS256)
 ├── authoriser.py        # Composable authorisation rules (GroupRule, EmailRule)
 ├── _base_auth.py        # Base auth class with shared logic
+├── df.py                # AuthorisedDataFrame (row-level security for DataFrames)
 ├── streamlit.py         # StreamlitAuth
 ├── dash.py              # DashAuth
 ├── fastapi.py           # FastAPIAuth

--- a/docs/api/authorised-dataframe.md
+++ b/docs/api/authorised-dataframe.md
@@ -50,9 +50,12 @@ df = pd.read_csv("data/spending.csv")
 spending = AuthorisedDataFrame.prepare(df, "department", DOMAIN_MAPPING)
 ```
 
-## Simple: Single DataFrame
+## Store Pattern (small datasets)
 
-One DataFrame, one callback, filtered by user:
+For small datasets or pages with a single rendering callback, use `to_store()`
+to push filtered data through a `dcc.Store`. One callback handles auth and
+writes to the Store; downstream callbacks read from it without any auth
+awareness:
 
 ```python
 @app.callback(
@@ -69,7 +72,9 @@ def filter_and_store(_n):
     return secure.to_store()
 ```
 
-`to_store()` returns a dict with `records`, `user_name`, `user_email`, `departments`, and `has_access` -- ready to write to `dcc.Store`. Downstream callbacks read from the Store:
+`to_store()` returns a dict with `records`, `user_name`, `user_email`,
+`departments`, and `has_access` -- ready to write to `dcc.Store`. Downstream
+callbacks read from the Store:
 
 ```python
 @app.callback(
@@ -81,6 +86,78 @@ def render_table(data):
         return []
     return data["records"]
 ```
+
+!!! warning "Performance consideration"
+    `to_store()` serialises the entire filtered DataFrame as JSON and sends it
+    to the browser. Every downstream callback that reads from the Store
+    receives the full payload back from the browser on each interaction.
+    For datasets larger than a few hundred rows, or pages with multiple
+    cascading callbacks, this can cause noticeable latency. Use the
+    **Direct Pattern** below instead.
+
+## Direct Pattern (larger datasets)
+
+For larger datasets or pages with cascading callbacks (e.g. filter dropdowns
+that trigger chart updates), call `auth.get_auth_user()` and
+`prepared.for_user(user)` directly in each callback. This keeps all data
+server-side -- nothing is serialised to the browser.
+
+Since `for_user()` is O(k) dict lookups (where k is the number of departments
+the user maps to), the per-callback overhead is negligible:
+
+```python
+prepared = AuthorisedDataFrame.prepare(df, "department", DOMAIN_MAPPING)
+
+
+def _get_user_df():
+    """Get the auth-filtered DataFrame for the current request user."""
+    user = auth.get_auth_user()
+    return prepared.for_user(user)
+
+
+@app.callback(
+    Output("filter-dept", "options"),
+    Input("url", "pathname"),
+)
+def update_dept_options(pathname):
+    secure = _get_user_df()
+    if not secure.has_access:
+        return []
+    return [
+        {"label": d, "value": d}
+        for d in sorted(secure.df["department"].dropna().unique())
+    ]
+
+
+@app.callback(
+    Output("chart", "children"),
+    [Input("filter-dept", "value"), Input("filter-metric", "value")],
+)
+def update_chart(dept_vals, metric):
+    secure = _get_user_df()
+    if not secure.has_access:
+        return html.Div("No data available for your department.")
+
+    dff = secure.df
+    if dept_vals:
+        dff = dff[dff["department"].isin(dept_vals)]
+
+    # ... build chart from dff ...
+```
+
+A shared `_get_user_df()` helper keeps the auth + filtering logic in one
+place. Each callback gets a fresh, already-filtered DataFrame without any
+JSON serialisation round-trip.
+
+## Choosing a Pattern
+
+| Pattern | Best for | Tradeoff |
+|---------|----------|----------|
+| **Store** | Small datasets, single render callback | Full data round-trips through the browser as JSON |
+| **Direct** | Larger datasets, cascading callbacks | `auth.get_auth_user()` called per callback (negligible cost) |
+
+Both patterns enforce the same security boundary: users only ever see rows
+for their authorised departments, and admin users see everything.
 
 ## DataModel: Multiple DataFrames
 
@@ -101,19 +178,16 @@ Then in a callback, call `.for_user()` on each:
 
 ```python
 @app.callback(...)
-def filter_and_store(_n):
+def update_dashboard(dept_vals, metric):
     user = auth.get_auth_user()
 
     secure_spending = data_model.spending.for_user(user)
     secure_forecasts = data_model.forecasts.for_user(user)
 
     if not secure_spending.has_access:
-        return None
+        return html.Div("No data available for your department.")
 
-    return {
-        "spending": secure_spending.df.to_dict("records"),
-        "forecasts": secure_forecasts.df.to_dict("records"),
-    }
+    # ... build dashboard from secure_spending.df, secure_forecasts.df ...
 ```
 
 DataFrames can use different column names -- just specify the column in `prepare()`:

--- a/docs/api/authorised-dataframe.md
+++ b/docs/api/authorised-dataframe.md
@@ -1,0 +1,149 @@
+# AuthorisedDataFrame
+
+Row-level security for pandas DataFrames.
+
+::: cognito_auth.df.AuthorisedDataFrame
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - __init__
+        - from_dataframe
+        - to_store
+
+## Installation
+
+AuthorisedDataFrame requires the `[df]` extra:
+
+```bash
+pip install cognito-auth[df]
+
+# Or with Dash support:
+pip install cognito-auth[dash,df]
+```
+
+## Quick Start
+
+```python
+from cognito_auth.dash import DashAuth
+from cognito_auth.df import AuthorisedDataFrame
+
+auth = DashAuth()
+auth.protect_app(app)
+
+# Pre-segment your data once at startup
+df = pd.read_csv("data/spending.csv")
+SEGMENTS = dict(tuple(df.groupby("department")))
+
+DOMAIN_MAPPING = {
+    "cabinetoffice.gov.uk": ["Cabinet Office"],
+    "homeoffice.gov.uk": ["Home Office"],
+    "hmrc.gov.uk": ["HMRC"],
+}
+```
+
+## Simple: Single DataFrame
+
+The most straightforward usage -- one DataFrame, one callback, filtered by user:
+
+```python
+@app.callback(
+    Output("filtered-data", "data"),
+    Input("trigger", "n_intervals"),
+)
+def filter_and_store(_n):
+    user = auth.get_auth_user()
+    secure = AuthorisedDataFrame(SEGMENTS, user, DOMAIN_MAPPING)
+
+    if not secure.has_access:
+        return None
+
+    return secure.to_store()
+```
+
+`to_store()` returns a dict with `records`, `user_name`, `user_email`, `departments`, and `has_access` -- ready to write to `dcc.Store`. Downstream callbacks read from the Store:
+
+```python
+@app.callback(
+    Output("table", "data"),
+    Input("filtered-data", "data"),
+)
+def render_table(data):
+    if not data or not data["has_access"]:
+        return []
+    return data["records"]
+```
+
+## DataModel: Multiple DataFrames
+
+For apps with multiple data sources, create one `AuthorisedDataFrame` per source:
+
+```python
+class DashboardDataModel:
+    def __init__(self, spending_df, forecast_df, domain_mapping):
+        self._spending_segments = dict(tuple(spending_df.groupby("department")))
+        self._forecast_segments = dict(tuple(forecast_df.groupby("department")))
+        self._mapping = domain_mapping
+
+    def secure_spending(self, user):
+        return AuthorisedDataFrame(
+            self._spending_segments, user, self._mapping
+        )
+
+    def secure_forecasts(self, user):
+        return AuthorisedDataFrame(
+            self._forecast_segments, user, self._mapping
+        )
+```
+
+```python
+@app.callback(...)
+def filter_and_store(_n):
+    user = auth.get_auth_user()
+    spending = data_model.secure_spending(user)
+    forecasts = data_model.secure_forecasts(user)
+
+    if not spending.has_access:
+        return None
+
+    return {
+        "spending": spending.df.to_dict("records"),
+        "forecasts": forecasts.df.to_dict("records"),
+    }
+```
+
+## Convenience: from_dataframe()
+
+If you don't want to pre-segment, use `from_dataframe()` which segments on the fly:
+
+```python
+secure = AuthorisedDataFrame.from_dataframe(
+    df, "department", user, DOMAIN_MAPPING
+)
+```
+
+!!! tip "Pre-segment for performance"
+    For apps with repeated calls (e.g. multiple callbacks), pre-segment once at startup and use the main constructor. `from_dataframe()` re-segments on every call.
+
+## How It Works
+
+1. **User resolution**: The user's `email_domain` is looked up in the `domain_mapping` dict. Admin users (`user.is_admin`) get access to all departments.
+2. **Segment lookup**: The matching department DataFrames are retrieved via dict lookup -- O(1) per department, no full DataFrame scan.
+3. **Filtered `.df`**: The resulting `.df` property contains only the authorised rows. There is no way to access unfiltered data through the wrapper.
+
+## Domain Mapping
+
+The `domain_mapping` dict maps email domains to department names that match your data:
+
+```python
+DOMAIN_MAPPING = {
+    "cabinetoffice.gov.uk": ["Cabinet Office"],
+    "digital.cabinet-office.gov.uk": ["Cabinet Office"],
+    "homeoffice.gov.uk": ["Home Office"],
+    "hmrc.gov.uk": ["HMRC"],
+}
+```
+
+- Multiple domains can map to the same department
+- A single domain can map to multiple departments
+- Unmapped domains result in `has_access = False` and an empty DataFrame

--- a/docs/api/authorised-dataframe.md
+++ b/docs/api/authorised-dataframe.md
@@ -8,8 +8,15 @@ Row-level security for pandas DataFrames.
       show_source: true
       members:
         - __init__
-        - from_dataframe
+        - prepare
         - to_store
+
+::: cognito_auth.df.PreparedDataFrame
+    options:
+      show_root_heading: true
+      show_source: true
+      members:
+        - for_user
 
 ## Installation
 
@@ -25,26 +32,27 @@ pip install cognito-auth[dash,df]
 ## Quick Start
 
 ```python
+import pandas as pd
 from cognito_auth.dash import DashAuth
 from cognito_auth.df import AuthorisedDataFrame
 
 auth = DashAuth()
 auth.protect_app(app)
 
-# Pre-segment your data once at startup
-df = pd.read_csv("data/spending.csv")
-SEGMENTS = dict(tuple(df.groupby("department")))
-
 DOMAIN_MAPPING = {
     "cabinetoffice.gov.uk": ["Cabinet Office"],
     "homeoffice.gov.uk": ["Home Office"],
     "hmrc.gov.uk": ["HMRC"],
 }
+
+# Startup -- prepare once, segment the data by department
+df = pd.read_csv("data/spending.csv")
+spending = AuthorisedDataFrame.prepare(df, "department", DOMAIN_MAPPING)
 ```
 
 ## Simple: Single DataFrame
 
-The most straightforward usage -- one DataFrame, one callback, filtered by user:
+One DataFrame, one callback, filtered by user:
 
 ```python
 @app.callback(
@@ -53,7 +61,7 @@ The most straightforward usage -- one DataFrame, one callback, filtered by user:
 )
 def filter_and_store(_n):
     user = auth.get_auth_user()
-    secure = AuthorisedDataFrame(SEGMENTS, user, DOMAIN_MAPPING)
+    secure = spending.for_user(user)
 
     if not secure.has_access:
         return None
@@ -76,60 +84,57 @@ def render_table(data):
 
 ## DataModel: Multiple DataFrames
 
-For apps with multiple data sources, create one `AuthorisedDataFrame` per source:
+For apps with multiple data sources, prepare each one at startup:
 
 ```python
 class DashboardDataModel:
     def __init__(self, spending_df, forecast_df, domain_mapping):
-        self._spending_segments = dict(tuple(spending_df.groupby("department")))
-        self._forecast_segments = dict(tuple(forecast_df.groupby("department")))
-        self._mapping = domain_mapping
-
-    def secure_spending(self, user):
-        return AuthorisedDataFrame(
-            self._spending_segments, user, self._mapping
+        self.spending = AuthorisedDataFrame.prepare(
+            spending_df, "department", domain_mapping
         )
-
-    def secure_forecasts(self, user):
-        return AuthorisedDataFrame(
-            self._forecast_segments, user, self._mapping
+        self.forecasts = AuthorisedDataFrame.prepare(
+            forecast_df, "department", domain_mapping
         )
 ```
+
+Then in a callback, call `.for_user()` on each:
 
 ```python
 @app.callback(...)
 def filter_and_store(_n):
     user = auth.get_auth_user()
-    spending = data_model.secure_spending(user)
-    forecasts = data_model.secure_forecasts(user)
 
-    if not spending.has_access:
+    secure_spending = data_model.spending.for_user(user)
+    secure_forecasts = data_model.forecasts.for_user(user)
+
+    if not secure_spending.has_access:
         return None
 
     return {
-        "spending": spending.df.to_dict("records"),
-        "forecasts": forecasts.df.to_dict("records"),
+        "spending": secure_spending.df.to_dict("records"),
+        "forecasts": secure_forecasts.df.to_dict("records"),
     }
 ```
 
-## Convenience: from_dataframe()
-
-If you don't want to pre-segment, use `from_dataframe()` which segments on the fly:
+DataFrames can use different column names -- just specify the column in `prepare()`:
 
 ```python
-secure = AuthorisedDataFrame.from_dataframe(
-    df, "department", user, DOMAIN_MAPPING
+# One dataset uses "department", another uses "OrganisationSubmitter"
+self.assessments = AuthorisedDataFrame.prepare(
+    assessments_df, "department", domain_mapping
+)
+self.spend = AuthorisedDataFrame.prepare(
+    spend_df, "OrganisationSubmitter", domain_mapping
 )
 ```
 
-!!! tip "Pre-segment for performance"
-    For apps with repeated calls (e.g. multiple callbacks), pre-segment once at startup and use the main constructor. `from_dataframe()` re-segments on every call.
-
 ## How It Works
 
-1. **User resolution**: The user's `email_domain` is looked up in the `domain_mapping` dict. Admin users (`user.is_admin`) get access to all departments.
-2. **Segment lookup**: The matching department DataFrames are retrieved via dict lookup -- O(1) per department, no full DataFrame scan.
-3. **Filtered `.df`**: The resulting `.df` property contains only the authorised rows. There is no way to access unfiltered data through the wrapper.
+1. **`prepare()`**: Segments the DataFrame by the auth column using `groupby` -- this happens once at startup.
+2. **`for_user()`**: Resolves the user's `email_domain` to departments via the mapping, then picks the matching segments via dict lookup -- O(1) per department.
+3. **`.df`**: The resulting DataFrame contains only authorised rows. There is no way to access unfiltered data through the wrapper.
+
+Admin users (`user.is_admin`) automatically get access to all departments in the mapping.
 
 ## Domain Mapping
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
   - API Reference:
       - User: api/user.md
       - Authoriser: api/authoriser.md
+      - AuthorisedDataFrame: api/authorised-dataframe.md
       - StreamlitAuth: api/streamlit-auth.md
       - DashAuth: api/dash-auth.md
       - FastAPIAuth: api/fastapi-auth.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-auth"
-version = "0.3.2"
+version = "0.4.0"
 description = "Unified authentication and authorisation for AWS Cognito-protected web applications across multiple frameworks"
 readme = "README.md"
 authors = [
@@ -21,12 +21,14 @@ streamlit = ["streamlit>=1.0.0"]
 dash = ["dash>=2.0.0", "flask>=2.0.0"]
 fastapi = ["fastapi>=0.100.0"]
 gradio = ["gradio>=4.0.0"]
+df = ["pandas>=2.2.0"]
 all = [
     "streamlit>=1.0.0",
     "dash>=2.0.0",
     "flask>=2.0.0",
     "fastapi>=0.100.0",
     "gradio>=4.0.0",
+    "pandas>=2.2.0",
 ]
 
 [build-system]
@@ -41,6 +43,7 @@ dev = [
     "mkdocs>=1.6.0",
     "mkdocs-material>=9.5.0",
     "mkdocstrings[python]>=0.26.0",
+    "pandas>=2.2.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/cognito_auth/df.py
+++ b/src/cognito_auth/df.py
@@ -13,5 +13,48 @@ Usage:
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cognito_auth.user import User
 
 logger = logging.getLogger(__name__)
+
+
+class AuthorisedDataFrame:
+    """DataFrame wrapper that only contains rows a user is authorised to see.
+
+    Resolves a user's email domain to departments via a mapping dict,
+    then filters the data so only authorised rows are accessible.
+
+    Args:
+        segments: Pre-segmented data as ``{department_name: DataFrame}``.
+            Create with ``dict(tuple(df.groupby(auth_column)))``.
+        user: Authenticated User object from cognito_auth.
+        domain_mapping: Maps email domains to lists of department names,
+            e.g. ``{"cabinetoffice.gov.uk": ["Cabinet Office"]}``.
+
+    Attributes:
+        user: The authenticated user this frame is filtered for.
+        departments: The departments this user can access, or None.
+        has_access: Whether the user has any department mapping.
+        df: The filtered DataFrame. Only contains authorised rows.
+    """
+
+    @staticmethod
+    def _resolve(user: User, mapping: dict[str, list[str]]) -> list[str] | None:
+        """Resolve a user to their authorised departments.
+
+        Admin users (``user.is_admin``) get access to all departments
+        in the mapping. Standard users are looked up by email domain.
+
+        Args:
+            user: Authenticated User from cognito_auth.
+            mapping: Domain-to-departments mapping dict.
+
+        Returns:
+            Sorted list of department names, or None if unmapped.
+        """
+        if user.is_admin:
+            return sorted({d for depts in mapping.values() for d in depts})
+        return mapping.get(user.email_domain)

--- a/src/cognito_auth/df.py
+++ b/src/cognito_auth/df.py
@@ -1,0 +1,17 @@
+"""
+AuthorisedDataFrame: Row-level security for pandas DataFrames.
+
+Provides a DataFrame wrapper that enforces department-based filtering
+based on a User's identity. Requires the [df] extra:
+
+    pip install cognito-auth[df]
+
+Usage:
+    from cognito_auth.df import AuthorisedDataFrame
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)

--- a/src/cognito_auth/df.py
+++ b/src/cognito_auth/df.py
@@ -13,7 +13,7 @@ Usage:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
@@ -85,3 +85,26 @@ class AuthorisedDataFrame:
         if user.is_admin:
             return sorted({d for depts in mapping.values() for d in depts})
         return mapping.get(user.email_domain)
+
+    def to_store(self) -> dict[str, Any]:
+        """Serialise for Dash ``dcc.Store`` -- filtered data + user context.
+
+        Returns a dict suitable for writing directly to a ``dcc.Store``
+        component. Downstream render callbacks can read from the store
+        without needing access to auth or the raw data.
+
+        Returns:
+            Dict with keys:
+                - ``records``: list of row dicts (empty if no access)
+                - ``user_name``: user's display name
+                - ``user_email``: user's email address
+                - ``departments``: list of authorised department names
+                - ``has_access``: whether the user has a department mapping
+        """
+        return {
+            "records": self.df.to_dict("records") if self.has_access else [],
+            "user_name": self.user.name,
+            "user_email": self.user.email,
+            "departments": self.departments,
+            "has_access": self.has_access,
+        }

--- a/src/cognito_auth/df.py
+++ b/src/cognito_auth/df.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+import pandas as pd
+
 if TYPE_CHECKING:
     from cognito_auth.user import User
 
@@ -40,6 +42,31 @@ class AuthorisedDataFrame:
         has_access: Whether the user has any department mapping.
         df: The filtered DataFrame. Only contains authorised rows.
     """
+
+    def __init__(
+        self,
+        segments: dict[str, pd.DataFrame],
+        user: User,
+        domain_mapping: dict[str, list[str]],
+    ) -> None:
+        self.user = user
+        self.departments = self._resolve(user, domain_mapping)
+        self.has_access = self.departments is not None
+
+        if not self.has_access or not self.departments:
+            # Get columns from the first segment if available, else empty
+            sample = next(iter(segments.values()), pd.DataFrame())
+            self.df = pd.DataFrame(columns=sample.columns)
+            return
+
+        matching = [segments[d] for d in self.departments if d in segments]
+        if not matching:
+            sample = next(iter(segments.values()), pd.DataFrame())
+            self.df = pd.DataFrame(columns=sample.columns)
+        elif len(matching) == 1:
+            self.df = matching[0]
+        else:
+            self.df = pd.concat(matching, ignore_index=True)
 
     @staticmethod
     def _resolve(user: User, mapping: dict[str, list[str]]) -> list[str] | None:

--- a/src/cognito_auth/df.py
+++ b/src/cognito_auth/df.py
@@ -108,3 +108,35 @@ class AuthorisedDataFrame:
             "departments": self.departments,
             "has_access": self.has_access,
         }
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        df: pd.DataFrame,
+        auth_column: str,
+        user: User,
+        domain_mapping: dict[str, list[str]],
+    ) -> AuthorisedDataFrame:
+        """Create from a raw DataFrame by segmenting on a column.
+
+        Convenience constructor that segments the DataFrame by
+        ``auth_column`` using ``groupby``, then delegates to the
+        standard constructor.
+
+        For better performance with repeated calls, pre-segment once
+        at app startup and use the main constructor directly::
+
+            SEGMENTS = dict(tuple(df.groupby("department")))
+            secure = AuthorisedDataFrame(SEGMENTS, user, mapping)
+
+        Args:
+            df: The full unfiltered DataFrame.
+            auth_column: Column name to segment/filter on.
+            user: Authenticated User from cognito_auth.
+            domain_mapping: Domain-to-departments mapping dict.
+
+        Returns:
+            AuthorisedDataFrame with only the user's authorised rows.
+        """
+        segments = dict(tuple(df.groupby(auth_column)))
+        return cls(segments, user, domain_mapping)

--- a/src/cognito_auth/df.py
+++ b/src/cognito_auth/df.py
@@ -8,6 +8,13 @@ based on a User's identity. Requires the [df] extra:
 
 Usage:
     from cognito_auth.df import AuthorisedDataFrame
+
+    # Startup -- segment once
+    spending = AuthorisedDataFrame.prepare(df, "department", DOMAIN_MAPPING)
+
+    # Per request -- filter for the current user
+    secure = spending.for_user(user)
+    secure.df  # only their rows
 """
 
 from __future__ import annotations
@@ -110,33 +117,67 @@ class AuthorisedDataFrame:
         }
 
     @classmethod
-    def from_dataframe(
+    def prepare(
         cls,
         df: pd.DataFrame,
         auth_column: str,
-        user: User,
         domain_mapping: dict[str, list[str]],
-    ) -> AuthorisedDataFrame:
-        """Create from a raw DataFrame by segmenting on a column.
+    ) -> PreparedDataFrame:
+        """Pre-segment a DataFrame for repeated per-user filtering.
 
-        Convenience constructor that segments the DataFrame by
-        ``auth_column`` using ``groupby``, then delegates to the
-        standard constructor.
+        Call this once at app startup to segment the data by
+        ``auth_column``. Then call ``.for_user(user)`` on the result
+        for each request to get a filtered :class:`AuthorisedDataFrame`.
 
-        For better performance with repeated calls, pre-segment once
-        at app startup and use the main constructor directly::
+        Example::
 
-            SEGMENTS = dict(tuple(df.groupby("department")))
-            secure = AuthorisedDataFrame(SEGMENTS, user, mapping)
+            # Startup
+            spending = AuthorisedDataFrame.prepare(df, "department", MAPPING)
+
+            # Per request
+            secure = spending.for_user(user)
+            secure.df  # filtered
 
         Args:
             df: The full unfiltered DataFrame.
-            auth_column: Column name to segment/filter on.
-            user: Authenticated User from cognito_auth.
+            auth_column: Column name to segment on (e.g. ``"department"``).
             domain_mapping: Domain-to-departments mapping dict.
 
         Returns:
-            AuthorisedDataFrame with only the user's authorised rows.
+            A :class:`PreparedDataFrame` ready for ``.for_user()`` calls.
         """
         segments = dict(tuple(df.groupby(auth_column)))
-        return cls(segments, user, domain_mapping)
+        return PreparedDataFrame(segments, domain_mapping)
+
+
+class PreparedDataFrame:
+    """Pre-segmented data ready to be filtered per user.
+
+    Created by :meth:`AuthorisedDataFrame.prepare`. Call
+    :meth:`for_user` to get a filtered :class:`AuthorisedDataFrame`
+    for a specific user.
+
+    Args:
+        segments: Pre-segmented data as ``{department_name: DataFrame}``.
+        domain_mapping: Domain-to-departments mapping dict.
+    """
+
+    def __init__(
+        self,
+        segments: dict[str, pd.DataFrame],
+        domain_mapping: dict[str, list[str]],
+    ) -> None:
+        self._segments = segments
+        self._domain_mapping = domain_mapping
+
+    def for_user(self, user: User) -> AuthorisedDataFrame:
+        """Create a filtered DataFrame for a specific user.
+
+        Args:
+            user: Authenticated User from cognito_auth.
+
+        Returns:
+            :class:`AuthorisedDataFrame` containing only rows the
+            user is authorised to see.
+        """
+        return AuthorisedDataFrame(self._segments, user, self._domain_mapping)

--- a/tests/cognito_auth/test_authorised_dataframe.py
+++ b/tests/cognito_auth/test_authorised_dataframe.py
@@ -225,3 +225,39 @@ class TestToStore:
         store = secure.to_store()
         assert store["has_access"] is False
         assert store["departments"] is None
+
+
+# ---------------------------------------------------------------------------
+# from_dataframe() tests
+# ---------------------------------------------------------------------------
+
+
+class TestFromDataFrame:
+    """Tests for AuthorisedDataFrame.from_dataframe() convenience constructor."""
+
+    def test_produces_same_result_as_presegmented(
+        self, sample_df, segments, cabinet_office_user
+    ):
+        from_segments = AuthorisedDataFrame(
+            segments, cabinet_office_user, DOMAIN_MAPPING
+        )
+        from_df = AuthorisedDataFrame.from_dataframe(
+            sample_df, "department", cabinet_office_user, DOMAIN_MAPPING
+        )
+        pd.testing.assert_frame_equal(
+            from_segments.df.reset_index(drop=True),
+            from_df.df.reset_index(drop=True),
+        )
+
+    def test_with_different_column_name(self, suppress_warnings):
+        """Works with any column name, not just 'department'."""
+        df = pd.DataFrame(
+            {
+                "org": ["Cabinet Office", "Home Office"],
+                "value": [10, 20],
+            }
+        )
+        user = User.create_mock(email="dev@cabinetoffice.gov.uk", groups=[])
+        secure = AuthorisedDataFrame.from_dataframe(df, "org", user, DOMAIN_MAPPING)
+        assert len(secure.df) == 1
+        assert secure.df.iloc[0]["org"] == "Cabinet Office"

--- a/tests/cognito_auth/test_authorised_dataframe.py
+++ b/tests/cognito_auth/test_authorised_dataframe.py
@@ -1,0 +1,91 @@
+"""Tests for AuthorisedDataFrame."""
+
+import warnings
+
+import pytest
+
+from cognito_auth import User
+from cognito_auth.df import AuthorisedDataFrame
+
+DOMAIN_MAPPING = {
+    "cabinetoffice.gov.uk": ["Cabinet Office"],
+    "digital.cabinet-office.gov.uk": ["Cabinet Office"],
+    "homeoffice.gov.uk": ["Home Office"],
+    "hmrc.gov.uk": ["HMRC"],
+}
+
+
+@pytest.fixture
+def suppress_warnings():
+    """Suppress UserWarnings from User.create_mock()."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        yield
+
+
+@pytest.fixture
+def cabinet_office_user(suppress_warnings):
+    return User.create_mock(email="dev@cabinetoffice.gov.uk", groups=[])
+
+
+@pytest.fixture
+def home_office_user(suppress_warnings):
+    return User.create_mock(email="dev@homeoffice.gov.uk", groups=[])
+
+
+@pytest.fixture
+def admin_user(suppress_warnings):
+    return User.create_mock(email="admin@cabinetoffice.gov.uk", groups=["gds-idea"])
+
+
+@pytest.fixture
+def unmapped_user(suppress_warnings):
+    return User.create_mock(email="someone@unknown.gov.uk", groups=[])
+
+
+# ---------------------------------------------------------------------------
+# _resolve() tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolve:
+    """Tests for AuthorisedDataFrame._resolve() static method."""
+
+    def test_mapped_domain_returns_departments(self, cabinet_office_user):
+        result = AuthorisedDataFrame._resolve(cabinet_office_user, DOMAIN_MAPPING)
+        assert result == ["Cabinet Office"]
+
+    def test_different_domain_returns_different_departments(self, home_office_user):
+        result = AuthorisedDataFrame._resolve(home_office_user, DOMAIN_MAPPING)
+        assert result == ["Home Office"]
+
+    def test_unmapped_domain_returns_none(self, unmapped_user):
+        result = AuthorisedDataFrame._resolve(unmapped_user, DOMAIN_MAPPING)
+        assert result is None
+
+    def test_admin_gets_all_departments_sorted(self, admin_user):
+        result = AuthorisedDataFrame._resolve(admin_user, DOMAIN_MAPPING)
+        assert result == ["Cabinet Office", "HMRC", "Home Office"]
+
+    def test_multiple_domains_map_to_same_department(self, suppress_warnings):
+        """digital.cabinet-office.gov.uk also maps to Cabinet Office."""
+        user = User.create_mock(email="dev@digital.cabinet-office.gov.uk", groups=[])
+        result = AuthorisedDataFrame._resolve(user, DOMAIN_MAPPING)
+        assert result == ["Cabinet Office"]
+
+    def test_domain_mapping_with_multiple_departments(self, suppress_warnings):
+        """A single domain can map to multiple departments."""
+        multi_mapping = {
+            "cabinetoffice.gov.uk": ["Cabinet Office", "CDDO"],
+        }
+        user = User.create_mock(email="dev@cabinetoffice.gov.uk", groups=[])
+        result = AuthorisedDataFrame._resolve(user, multi_mapping)
+        assert result == ["Cabinet Office", "CDDO"]
+
+    def test_empty_mapping_returns_none(self, cabinet_office_user):
+        result = AuthorisedDataFrame._resolve(cabinet_office_user, {})
+        assert result is None
+
+    def test_admin_with_empty_mapping_returns_empty_list(self, admin_user):
+        result = AuthorisedDataFrame._resolve(admin_user, {})
+        assert result == []

--- a/tests/cognito_auth/test_authorised_dataframe.py
+++ b/tests/cognito_auth/test_authorised_dataframe.py
@@ -180,3 +180,48 @@ class TestFiltering:
         secure = AuthorisedDataFrame(segments, user, DOMAIN_MAPPING)
         assert len(secure.df) == 0
         assert secure.has_access is True  # they have access, just no data
+
+
+# ---------------------------------------------------------------------------
+# to_store() tests
+# ---------------------------------------------------------------------------
+
+
+class TestToStore:
+    """Tests for AuthorisedDataFrame.to_store() serialisation."""
+
+    def test_returns_correct_keys(self, segments, cabinet_office_user):
+        secure = AuthorisedDataFrame(segments, cabinet_office_user, DOMAIN_MAPPING)
+        store = secure.to_store()
+        assert set(store.keys()) == {
+            "records",
+            "user_name",
+            "user_email",
+            "departments",
+            "has_access",
+        }
+
+    def test_records_match_filtered_data(self, segments, cabinet_office_user):
+        secure = AuthorisedDataFrame(segments, cabinet_office_user, DOMAIN_MAPPING)
+        store = secure.to_store()
+        assert store["records"] == secure.df.to_dict("records")
+        assert len(store["records"]) == 2
+
+    def test_includes_user_context(self, segments, cabinet_office_user):
+        secure = AuthorisedDataFrame(segments, cabinet_office_user, DOMAIN_MAPPING)
+        store = secure.to_store()
+        assert store["user_name"] == cabinet_office_user.name
+        assert store["user_email"] == cabinet_office_user.email
+        assert store["departments"] == ["Cabinet Office"]
+        assert store["has_access"] is True
+
+    def test_no_access_returns_empty_records(self, segments, unmapped_user):
+        secure = AuthorisedDataFrame(segments, unmapped_user, DOMAIN_MAPPING)
+        store = secure.to_store()
+        assert store["records"] == []
+
+    def test_no_access_has_access_false(self, segments, unmapped_user):
+        secure = AuthorisedDataFrame(segments, unmapped_user, DOMAIN_MAPPING)
+        store = secure.to_store()
+        assert store["has_access"] is False
+        assert store["departments"] is None

--- a/tests/cognito_auth/test_authorised_dataframe.py
+++ b/tests/cognito_auth/test_authorised_dataframe.py
@@ -2,6 +2,7 @@
 
 import warnings
 
+import pandas as pd
 import pytest
 
 from cognito_auth import User
@@ -41,6 +42,27 @@ def admin_user(suppress_warnings):
 @pytest.fixture
 def unmapped_user(suppress_warnings):
     return User.create_mock(email="someone@unknown.gov.uk", groups=[])
+
+
+@pytest.fixture
+def sample_df():
+    return pd.DataFrame(
+        {
+            "department": [
+                "Cabinet Office",
+                "Cabinet Office",
+                "Home Office",
+                "HMRC",
+            ],
+            "project": ["Project A", "Project B", "Project C", "Project D"],
+            "budget": [100, 200, 300, 400],
+        }
+    )
+
+
+@pytest.fixture
+def segments(sample_df):
+    return dict(tuple(sample_df.groupby("department")))
 
 
 # ---------------------------------------------------------------------------
@@ -89,3 +111,72 @@ class TestResolve:
     def test_admin_with_empty_mapping_returns_empty_list(self, admin_user):
         result = AuthorisedDataFrame._resolve(admin_user, {})
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# __init__ / filtering tests
+# ---------------------------------------------------------------------------
+
+
+class TestFiltering:
+    """Tests for AuthorisedDataFrame construction and row-level filtering."""
+
+    def test_single_department_user_sees_only_their_rows(
+        self, segments, cabinet_office_user
+    ):
+        secure = AuthorisedDataFrame(segments, cabinet_office_user, DOMAIN_MAPPING)
+        assert len(secure.df) == 2
+        assert set(secure.df["department"]) == {"Cabinet Office"}
+
+    def test_different_department_user_sees_different_rows(
+        self, segments, home_office_user
+    ):
+        secure = AuthorisedDataFrame(segments, home_office_user, DOMAIN_MAPPING)
+        assert len(secure.df) == 1
+        assert set(secure.df["department"]) == {"Home Office"}
+
+    def test_admin_sees_all_rows(self, segments, admin_user):
+        secure = AuthorisedDataFrame(segments, admin_user, DOMAIN_MAPPING)
+        assert len(secure.df) == 4
+
+    def test_unmapped_user_gets_empty_dataframe(self, segments, unmapped_user):
+        secure = AuthorisedDataFrame(segments, unmapped_user, DOMAIN_MAPPING)
+        assert len(secure.df) == 0
+
+    def test_unmapped_user_preserves_columns(self, segments, unmapped_user):
+        secure = AuthorisedDataFrame(segments, unmapped_user, DOMAIN_MAPPING)
+        assert list(secure.df.columns) == ["department", "project", "budget"]
+
+    def test_has_access_true_for_mapped_user(self, segments, cabinet_office_user):
+        secure = AuthorisedDataFrame(segments, cabinet_office_user, DOMAIN_MAPPING)
+        assert secure.has_access is True
+
+    def test_has_access_false_for_unmapped_user(self, segments, unmapped_user):
+        secure = AuthorisedDataFrame(segments, unmapped_user, DOMAIN_MAPPING)
+        assert secure.has_access is False
+
+    def test_user_property_returns_original_user(self, segments, cabinet_office_user):
+        secure = AuthorisedDataFrame(segments, cabinet_office_user, DOMAIN_MAPPING)
+        assert secure.user is cabinet_office_user
+
+    def test_departments_property(self, segments, cabinet_office_user):
+        secure = AuthorisedDataFrame(segments, cabinet_office_user, DOMAIN_MAPPING)
+        assert secure.departments == ["Cabinet Office"]
+
+    def test_departments_none_for_unmapped_user(self, segments, unmapped_user):
+        secure = AuthorisedDataFrame(segments, unmapped_user, DOMAIN_MAPPING)
+        assert secure.departments is None
+
+    def test_empty_segments_returns_empty_dataframe(self, cabinet_office_user):
+        secure = AuthorisedDataFrame({}, cabinet_office_user, DOMAIN_MAPPING)
+        assert len(secure.df) == 0
+
+    def test_department_not_in_segments(self, suppress_warnings):
+        """User maps to a department that has no rows in the data."""
+        segments = {
+            "Home Office": pd.DataFrame({"department": ["Home Office"], "x": [1]}),
+        }
+        user = User.create_mock(email="dev@hmrc.gov.uk", groups=[])
+        secure = AuthorisedDataFrame(segments, user, DOMAIN_MAPPING)
+        assert len(secure.df) == 0
+        assert secure.has_access is True  # they have access, just no data

--- a/tests/cognito_auth/test_authorised_dataframe.py
+++ b/tests/cognito_auth/test_authorised_dataframe.py
@@ -261,3 +261,73 @@ class TestFromDataFrame:
         secure = AuthorisedDataFrame.from_dataframe(df, "org", user, DOMAIN_MAPPING)
         assert len(secure.df) == 1
         assert secure.df.iloc[0]["org"] == "Cabinet Office"
+
+
+# ---------------------------------------------------------------------------
+# DataModel pattern tests
+# ---------------------------------------------------------------------------
+
+
+class TestDataModelPattern:
+    """Tests demonstrating the DataModel usage pattern with multiple DataFrames.
+
+    This shows how an app with multiple data sources would use
+    AuthorisedDataFrame -- one wrapper per source DataFrame, same user,
+    same mapping.
+    """
+
+    def test_multiple_dataframes_same_user(self, cabinet_office_user):
+        """Two DataFrames filtered for the same user."""
+        spending_df = pd.DataFrame(
+            {
+                "department": ["Cabinet Office", "Home Office"],
+                "budget": [100, 200],
+            }
+        )
+        forecast_df = pd.DataFrame(
+            {
+                "department": ["Cabinet Office", "Home Office", "HMRC"],
+                "forecast": [150, 250, 350],
+            }
+        )
+        spending_segments = dict(tuple(spending_df.groupby("department")))
+        forecast_segments = dict(tuple(forecast_df.groupby("department")))
+
+        secure_spending = AuthorisedDataFrame(
+            spending_segments, cabinet_office_user, DOMAIN_MAPPING
+        )
+        secure_forecast = AuthorisedDataFrame(
+            forecast_segments, cabinet_office_user, DOMAIN_MAPPING
+        )
+
+        assert len(secure_spending.df) == 1
+        assert len(secure_forecast.df) == 1
+        assert secure_spending.df.iloc[0]["budget"] == 100
+        assert secure_forecast.df.iloc[0]["forecast"] == 150
+
+    def test_different_auth_columns(self, cabinet_office_user):
+        """DataFrames can use different column names for department."""
+        df_short = pd.DataFrame(
+            {
+                "dept": ["Cabinet Office", "Home Office"],
+                "x": [1, 2],
+            }
+        )
+        df_long = pd.DataFrame(
+            {
+                "organisation": ["Cabinet Office", "HMRC"],
+                "y": [3, 4],
+            }
+        )
+
+        secure_short = AuthorisedDataFrame.from_dataframe(
+            df_short, "dept", cabinet_office_user, DOMAIN_MAPPING
+        )
+        secure_long = AuthorisedDataFrame.from_dataframe(
+            df_long, "organisation", cabinet_office_user, DOMAIN_MAPPING
+        )
+
+        assert len(secure_short.df) == 1
+        assert len(secure_long.df) == 1
+        assert secure_short.df.iloc[0]["x"] == 1
+        assert secure_long.df.iloc[0]["y"] == 3

--- a/tests/cognito_auth/test_authorised_dataframe.py
+++ b/tests/cognito_auth/test_authorised_dataframe.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from cognito_auth import User
-from cognito_auth.df import AuthorisedDataFrame
+from cognito_auth.df import AuthorisedDataFrame, PreparedDataFrame
 
 DOMAIN_MAPPING = {
     "cabinetoffice.gov.uk": ["Cabinet Office"],
@@ -228,28 +228,43 @@ class TestToStore:
 
 
 # ---------------------------------------------------------------------------
-# from_dataframe() tests
+# prepare() + for_user() tests
 # ---------------------------------------------------------------------------
 
 
-class TestFromDataFrame:
-    """Tests for AuthorisedDataFrame.from_dataframe() convenience constructor."""
+class TestPrepare:
+    """Tests for AuthorisedDataFrame.prepare() and PreparedDataFrame.for_user()."""
 
-    def test_produces_same_result_as_presegmented(
-        self, sample_df, segments, cabinet_office_user
-    ):
-        from_segments = AuthorisedDataFrame(
-            segments, cabinet_office_user, DOMAIN_MAPPING
-        )
-        from_df = AuthorisedDataFrame.from_dataframe(
-            sample_df, "department", cabinet_office_user, DOMAIN_MAPPING
-        )
+    def test_prepare_returns_prepared_dataframe(self, sample_df):
+        prepared = AuthorisedDataFrame.prepare(sample_df, "department", DOMAIN_MAPPING)
+        assert isinstance(prepared, PreparedDataFrame)
+
+    def test_for_user_filters_correctly(self, sample_df, segments, cabinet_office_user):
+        """prepare().for_user() gives same result as direct constructor."""
+        prepared = AuthorisedDataFrame.prepare(sample_df, "department", DOMAIN_MAPPING)
+        from_prepare = prepared.for_user(cabinet_office_user)
+        from_direct = AuthorisedDataFrame(segments, cabinet_office_user, DOMAIN_MAPPING)
         pd.testing.assert_frame_equal(
-            from_segments.df.reset_index(drop=True),
-            from_df.df.reset_index(drop=True),
+            from_prepare.df.reset_index(drop=True),
+            from_direct.df.reset_index(drop=True),
         )
 
-    def test_with_different_column_name(self, suppress_warnings):
+    def test_for_user_different_users_different_results(
+        self, sample_df, cabinet_office_user, home_office_user
+    ):
+        prepared = AuthorisedDataFrame.prepare(sample_df, "department", DOMAIN_MAPPING)
+        co = prepared.for_user(cabinet_office_user)
+        ho = prepared.for_user(home_office_user)
+        assert set(co.df["department"]) == {"Cabinet Office"}
+        assert set(ho.df["department"]) == {"Home Office"}
+
+    def test_for_user_unmapped_user(self, sample_df, unmapped_user):
+        prepared = AuthorisedDataFrame.prepare(sample_df, "department", DOMAIN_MAPPING)
+        secure = prepared.for_user(unmapped_user)
+        assert secure.has_access is False
+        assert len(secure.df) == 0
+
+    def test_prepare_with_different_column_name(self, suppress_warnings):
         """Works with any column name, not just 'department'."""
         df = pd.DataFrame(
             {
@@ -257,8 +272,9 @@ class TestFromDataFrame:
                 "value": [10, 20],
             }
         )
+        prepared = AuthorisedDataFrame.prepare(df, "org", DOMAIN_MAPPING)
         user = User.create_mock(email="dev@cabinetoffice.gov.uk", groups=[])
-        secure = AuthorisedDataFrame.from_dataframe(df, "org", user, DOMAIN_MAPPING)
+        secure = prepared.for_user(user)
         assert len(secure.df) == 1
         assert secure.df.iloc[0]["org"] == "Cabinet Office"
 
@@ -272,8 +288,8 @@ class TestDataModelPattern:
     """Tests demonstrating the DataModel usage pattern with multiple DataFrames.
 
     This shows how an app with multiple data sources would use
-    AuthorisedDataFrame -- one wrapper per source DataFrame, same user,
-    same mapping.
+    AuthorisedDataFrame.prepare() -- one prepared source per DataFrame,
+    same user, same mapping.
     """
 
     def test_multiple_dataframes_same_user(self, cabinet_office_user):
@@ -290,15 +306,16 @@ class TestDataModelPattern:
                 "forecast": [150, 250, 350],
             }
         )
-        spending_segments = dict(tuple(spending_df.groupby("department")))
-        forecast_segments = dict(tuple(forecast_df.groupby("department")))
 
-        secure_spending = AuthorisedDataFrame(
-            spending_segments, cabinet_office_user, DOMAIN_MAPPING
+        spending = AuthorisedDataFrame.prepare(
+            spending_df, "department", DOMAIN_MAPPING
         )
-        secure_forecast = AuthorisedDataFrame(
-            forecast_segments, cabinet_office_user, DOMAIN_MAPPING
+        forecasts = AuthorisedDataFrame.prepare(
+            forecast_df, "department", DOMAIN_MAPPING
         )
+
+        secure_spending = spending.for_user(cabinet_office_user)
+        secure_forecast = forecasts.for_user(cabinet_office_user)
 
         assert len(secure_spending.df) == 1
         assert len(secure_forecast.df) == 1
@@ -320,12 +337,11 @@ class TestDataModelPattern:
             }
         )
 
-        secure_short = AuthorisedDataFrame.from_dataframe(
-            df_short, "dept", cabinet_office_user, DOMAIN_MAPPING
-        )
-        secure_long = AuthorisedDataFrame.from_dataframe(
-            df_long, "organisation", cabinet_office_user, DOMAIN_MAPPING
-        )
+        short = AuthorisedDataFrame.prepare(df_short, "dept", DOMAIN_MAPPING)
+        long = AuthorisedDataFrame.prepare(df_long, "organisation", DOMAIN_MAPPING)
+
+        secure_short = short.for_user(cabinet_office_user)
+        secure_long = long.for_user(cabinet_office_user)
 
         assert len(secure_short.df) == 1
         assert len(secure_long.df) == 1


### PR DESCRIPTION
## Summary

Adds `AuthorisedDataFrame` to `cognito-auth` as a new optional extra `[df]`. It provides a DataFrame wrapper that enforces row-level security based on a `User`'s email domain, resolving departments via a mapping dict and returning only authorised rows.

## Usage

```python
from cognito_auth.df import AuthorisedDataFrame

DOMAIN_MAPPING = {
    "cabinetoffice.gov.uk": ["Cabinet Office"],
    "homeoffice.gov.uk": ["Home Office"],
}

# Startup -- prepare once
spending = AuthorisedDataFrame.prepare(df, "department", DOMAIN_MAPPING)

# Per request
secure = spending.for_user(user)
secure.df           # filtered DataFrame
secure.has_access   # bool
secure.departments  # ["Cabinet Office"]
secure.to_store()   # dict for dcc.Store
```

## What's included

- **`AuthorisedDataFrame`** class with `.prepare()`, `.to_store()`, `.df`, `.has_access`, `.user`, `.departments`
- **`PreparedDataFrame`** with `.for_user()` -- the recommended entry point
- **`[df]` optional extra** -- `pip install cognito-auth[df]` adds `pandas>=2.2.0`
- **32 tests** across 6 test classes (resolve, filtering, to_store, prepare, DataModel pattern)
- **API docs** with examples for single DataFrame and multi-DataFrame DataModel usage

## Key design decisions

- **Pre-segmented data**: `prepare()` uses `groupby` once at startup. `for_user()` is a dict lookup -- O(1) per department, no DataFrame scan per request
- **Admin bypass**: `user.is_admin` gets access to all departments
- **Unmapped domains**: `has_access = False`, empty DataFrame (not an error)
- **Duck-typed User**: Uses `TYPE_CHECKING` import -- no runtime dependency on `cognito_auth.user`
- **No caching needed**: Pre-segmentation makes per-request filtering effectively free

## Install

```bash
pip install cognito-auth[df]
# or
pip install cognito-auth[dash,df]
```

## To preview docs locally

```bash
git checkout feature/authorised-dataframe
uv sync
uv run mkdocs serve
# Visit http://127.0.0.1:8000/api/authorised-dataframe/
```