### PR TITLE
Add app-level admin support to Authoriser

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,60 @@
+name: Docs Preview
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: docs-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    name: Deploy Preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Build documentation
+        run: uv run mkdocs build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: site/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: deploy
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    name: Cleanup Preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,18 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --all-extras
 
       - name: Build documentation
         run: uv run mkdocs build
 
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: site/
-
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site/
+          # Keep PR preview directories when deploying main docs
+          keep_files: true
 
   create-release:
     name: Create GitHub Release

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.4.3"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.3.tgz",
+      "integrity": "sha512-Ob/3tVSIeuMRJBr2O23RtrnC5djRe01Lglx+TwGEmjrH9yDBJ2tftegYLnNEjRoMuzITgq9LD8168p4pzv+U/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.4.3",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.97",
+        "@opentui/solid": ">=0.1.97"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.3.tgz",
+      "integrity": "sha512-X0CAVbwoGAjTY2iecpWkx2B+GAa2jSaQKYpJ+xILopeF/OGKZUN15mjqci+L7cEuwLHV5wk3x2TStUOVCa5p0A==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/.opencode/plans/pypi-index-plan.md
+++ b/.opencode/plans/pypi-index-plan.md
@@ -1,0 +1,332 @@
+# PyPI Index Implementation Plan
+
+## Goal
+
+Create a private, GitHub Pages-hosted PyPI index that serves all internal `co-cddo` packages, enabling standard version ranges (`>=0.2.0`) instead of git URL pinning. Leverages GitHub Enterprise's ability to restrict Pages access to organisation members.
+
+---
+
+## Architecture
+
+```
+Consumer (pip/uv)
+    |
+    | https://co-cddo.github.io/pypi-index/simple/
+    | (restricted to co-cddo org members)
+    v
+co-cddo/pypi-index (private repo, GitHub Pages)
+    |
+    | /simple/index.html          -- lists all packages
+    | /simple/cognito-auth/       -- links to wheels
+    | /simple/gds-idea-app-kit/   -- links to wheels
+    | /simple/gds-idea-cdk-.../   -- links to wheels
+    | /packages/*.whl             -- actual wheel files
+    |
+    v
+Wheels downloaded from GitHub Release assets at build time
+    - co-cddo/gds-idea-app-auth     (public)
+    - co-cddo/gds-idea-app-kit      (public)
+    - co-cddo/gds-idea-cdk-constructs (private)
+```
+
+Key design decisions:
+- Wheels are **copied into the index repo's Pages site**, not linked to release assets. This avoids double-authentication issues (Pages auth + Release asset auth).
+- The index is a **private repo** with Pages restricted to org members.
+- One index URL for all packages -- consumers don't need to know which are public/private.
+
+---
+
+## New Repository: `co-cddo/pypi-index`
+
+### File Structure
+
+```
+co-cddo/pypi-index/
+├── .github/
+│   └── workflows/
+│       └── rebuild.yml          # GitHub Action to rebuild and deploy index
+├── packages.json                # Config: which repos to index
+├── build_index.py               # Script to generate the PEP 503 index
+├── requirements.txt             # Dependencies for build script (if any)
+└── README.md                    # Documentation for maintainers
+```
+
+The `site/` directory is generated at build time and deployed to Pages. It is never committed.
+
+### packages.json
+
+```json
+{
+  "repos": [
+    {
+      "repo": "co-cddo/gds-idea-app-auth",
+      "package_name": "cognito-auth"
+    },
+    {
+      "repo": "co-cddo/gds-idea-app-kit",
+      "package_name": "gds-idea-app-kit"
+    },
+    {
+      "repo": "co-cddo/gds-idea-cdk-constructs",
+      "package_name": "gds-idea-cdk-constructs"
+    }
+  ]
+}
+```
+
+### build_index.py
+
+A Python script (~100 lines, no external dependencies beyond `requests` or using `gh` CLI) that:
+
+1. Reads `packages.json`
+2. For each repo, calls `gh api repos/{repo}/releases` to list all releases
+3. For each release, downloads `.whl` and `.tar.gz` assets into `site/packages/`
+4. Generates `site/simple/index.html`:
+   ```html
+   <!DOCTYPE html>
+   <html><body>
+     <a href="cognito-auth/">cognito-auth</a>
+     <a href="gds-idea-app-kit/">gds-idea-app-kit</a>
+     <a href="gds-idea-cdk-constructs/">gds-idea-cdk-constructs</a>
+   </body></html>
+   ```
+5. For each package, generates `site/simple/{package-name}/index.html`:
+   ```html
+   <!DOCTYPE html>
+   <html><body>
+     <a href="../../packages/cognito_auth-0.2.3-py3-none-any.whl">
+       cognito_auth-0.2.3-py3-none-any.whl
+     </a>
+     <a href="../../packages/cognito_auth-0.2.2-py3-none-any.whl">
+       cognito_auth-0.2.2-py3-none-any.whl
+     </a>
+   </body></html>
+   ```
+
+This follows the PEP 503 Simple Repository API that pip/uv understand natively.
+
+### .github/workflows/rebuild.yml
+
+```yaml
+name: Rebuild PyPI Index
+
+on:
+  workflow_dispatch:       # Manual trigger
+  repository_dispatch:     # Triggered by package repos on release
+    types: [package-released]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build index
+        run: python build_index.py
+        env:
+          GH_TOKEN: ${{ secrets.PACKAGE_READER_TOKEN }}
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+```
+
+`PACKAGE_READER_TOKEN` is a fine-grained PAT with `contents:read` on all three package repos (needed to download release assets from the private repo).
+
+---
+
+## Changes to Package Repos
+
+### 1. co-cddo/gds-idea-app-auth (release.yml)
+
+Add after the "Create GitHub Release" step:
+
+```yaml
+      - name: Trigger PyPI index rebuild
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          gh api repos/co-cddo/pypi-index/dispatches \
+            -f event_type=package-released
+        env:
+          GH_TOKEN: ${{ secrets.PYPI_INDEX_TRIGGER_TOKEN }}
+```
+
+### 2. co-cddo/gds-idea-app-kit (release.yml)
+
+Same addition as above.
+
+### 3. co-cddo/gds-idea-cdk-constructs (release.yml)
+
+Same addition as above. If this repo doesn't have a release workflow that builds wheels and attaches them to releases, one needs to be created following the same pattern as `gds-idea-app-auth`.
+
+---
+
+## Changes to Consumer Configuration
+
+### gds-idea-app-kit templates
+
+Update `pyproject.toml.template` for each framework:
+
+**Before:**
+```toml
+dependencies = [
+    "cognito-auth[streamlit] @ git+https://github.com/co-cddo/gds-idea-app-auth.git",
+]
+```
+
+**After:**
+```toml
+[tool.uv]
+extra-index-url = ["https://co-cddo.github.io/pypi-index/simple/"]
+
+[project]
+dependencies = [
+    "cognito-auth[streamlit]>=0.2.0",
+]
+```
+
+### Dev container setup
+
+Add to the dev container's post-create or post-start command:
+
+```bash
+# Authenticate pip/uv with GitHub Pages (for private index)
+echo "machine co-cddo.github.io
+login x-access-token
+password ${GITHUB_TOKEN}" >> ~/.netrc
+chmod 600 ~/.netrc
+```
+
+The `GITHUB_TOKEN` is already available in GitHub Codespaces and can be injected into local dev containers via `gds-idea-app-kit`.
+
+### CI (GitHub Actions)
+
+In CI workflows that run `uv sync` or `pip install`, add:
+
+```yaml
+      - name: Configure private index auth
+        run: |
+          echo "machine co-cddo.github.io
+          login x-access-token
+          password ${{ secrets.GITHUB_TOKEN }}" >> ~/.netrc
+```
+
+`secrets.GITHUB_TOKEN` is automatically available in Actions and has read access to org-level Pages sites.
+
+---
+
+## GitHub Tokens Required
+
+| Token | Purpose | Scope | Stored where |
+|---|---|---|---|
+| `PACKAGE_READER_TOKEN` | Index rebuild workflow downloads release assets (including from private repos) | `contents:read` on all 3 package repos | `co-cddo/pypi-index` repo secret |
+| `PYPI_INDEX_TRIGGER_TOKEN` | Package repos trigger index rebuild on release | `actions:write` on `co-cddo/pypi-index` | Secret in each package repo |
+| `GITHUB_TOKEN` (automatic) | Consumers authenticate against private Pages site | Automatic in Actions/Codespaces | N/A (built-in) |
+
+Recommended: Use a **GitHub App** instead of PATs for `PACKAGE_READER_TOKEN` and `PYPI_INDEX_TRIGGER_TOKEN`. This avoids tokens being tied to a personal account and provides better audit logging. A single GitHub App installed on the org can have the necessary permissions.
+
+---
+
+## Changes to cognito-auth Documentation
+
+### README.md
+
+Update install section:
+
+```bash
+# Configure the private index (one-time setup)
+# See: https://github.com/co-cddo/pypi-index
+
+# Then install normally:
+pip install "cognito-auth[streamlit]>=0.2.0" \
+    --extra-index-url https://co-cddo.github.io/pypi-index/simple/
+```
+
+### docs/index.md
+
+Update the Installation section similarly. Add a note that `gds-idea-app-kit` projects come pre-configured.
+
+---
+
+## GitHub Pages Configuration
+
+After creating the `co-cddo/pypi-index` repo:
+
+1. Go to Settings > Pages
+2. Source: GitHub Actions
+3. Go to Settings > Pages > Access
+4. Set to: "Only members of co-cddo" (Enterprise feature)
+
+This ensures only authenticated org members can access the index and download wheels.
+
+---
+
+## Execution Steps (in order)
+
+### Phase 1: Create the index (30 min)
+
+1. Create `co-cddo/pypi-index` as a **private** repo
+2. Add `packages.json`, `build_index.py`, `.github/workflows/rebuild.yml`
+3. Create the `PACKAGE_READER_TOKEN` (fine-grained PAT or GitHub App)
+4. Add it as a repo secret on `pypi-index`
+5. Enable GitHub Pages (source: Actions, access: org members only)
+6. Run the workflow manually to seed the initial index
+7. Verify: visit `https://co-cddo.github.io/pypi-index/simple/` while logged in
+
+### Phase 2: Test the index (15 min)
+
+8. From a local machine (with `~/.netrc` configured):
+   ```bash
+   pip install "cognito-auth[streamlit]>=0.2.0" \
+       --extra-index-url https://co-cddo.github.io/pypi-index/simple/
+   ```
+9. Verify version resolution works (`>=0.2.0` installs latest)
+10. Test with `uv add` as well
+
+### Phase 3: Wire up automatic rebuilds (15 min)
+
+11. Create the `PYPI_INDEX_TRIGGER_TOKEN` (PAT or GitHub App)
+12. Add as secret to `gds-idea-app-auth`, `gds-idea-app-kit`, `gds-idea-cdk-constructs`
+13. Update release workflows in all three repos to trigger index rebuild
+14. Test: push a release, verify index updates automatically
+
+### Phase 4: Update consumers (30 min)
+
+15. Update `gds-idea-app-kit` templates (`pyproject.toml.template`, dev container config)
+16. Update `gds-idea-app-auth` docs (README.md, docs/index.md)
+17. Update any existing projects to use the new index URL
+
+---
+
+## Estimated Total Effort
+
+| Phase | Time |
+|---|---|
+| Create the index repo + script + workflow | 30 min |
+| Test end-to-end | 15 min |
+| Wire up automatic rebuilds | 15 min |
+| Update consumer templates and docs | 30 min |
+| **Total** | **~1.5 hours** |
+
+---
+
+## Future Considerations
+
+- **Adding a new package**: Add an entry to `packages.json`, ensure the repo has a release workflow that attaches wheels, add the `PYPI_INDEX_TRIGGER_TOKEN` secret, and re-run the index rebuild.
+- **Removing a package**: Remove from `packages.json` and re-run. Old wheels will no longer be served.
+- **SHA256 hashes**: For extra security, `build_index.py` can include `#sha256=...` fragments on download links (PEP 503 compliant). pip will verify wheel integrity. Worth adding.
+- **Migration path to public PyPI**: If you ever want to publish `cognito-auth` to public PyPI, the version numbers and wheel format are already compatible. Just add a `twine upload` step.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cognito-auth"
-version = "0.4.0"
+version = "0.5.0"
 description = "Unified authentication and authorisation for AWS Cognito-protected web applications across multiple frameworks"
 readme = "README.md"
 authors = [

--- a/src/cognito_auth/authoriser.py
+++ b/src/cognito_auth/authoriser.py
@@ -27,8 +27,10 @@ class AuthConfig(BaseModel):
     allowed_groups: list[str] | None = None
     allowed_users: list[str] | None = None
     require_all: bool = False
+    admin_groups: list[str] | None = None
+    admin_users: list[str] | None = None
 
-    @field_validator("allowed_users")
+    @field_validator("allowed_users", "admin_users")
     @classmethod
     def validate_emails(cls, v):
         """Validate that all users are valid email addresses."""

--- a/src/cognito_auth/authoriser.py
+++ b/src/cognito_auth/authoriser.py
@@ -144,9 +144,7 @@ class Authoriser:
         # App admins bypass access rules
         if self._is_app_admin(user):
             user.is_app_admin = True
-            logger.info(
-                "User is app admin, granting access: email=%s", user.email
-            )
+            logger.info("User is app admin, granting access: email=%s", user.email)
             return True
 
         if not self.rules:

--- a/src/cognito_auth/authoriser.py
+++ b/src/cognito_auth/authoriser.py
@@ -100,14 +100,34 @@ class EmailRule:
 class Authoriser:
     """Handles authorisation logic using composable rules"""
 
-    def __init__(self, rules: list[AuthorisationRule], require_all: bool = False):
+    def __init__(
+        self,
+        rules: list[AuthorisationRule],
+        require_all: bool = False,
+        admin_groups: set[str] | None = None,
+        admin_users: set[str] | None = None,
+    ):
         """
         Args:
             rules: List of authorisation rules
             require_all: If True, ALL rules must pass. If False, ANY rule can pass.
+            admin_groups: Cognito groups that grant app-admin status
+            admin_users: Email addresses that grant app-admin status
         """
         self.rules = rules
         self.require_all = require_all
+        self.admin_groups = admin_groups
+        self.admin_users = {e.lower() for e in admin_users} if admin_users else None
+
+    def _is_app_admin(self, user: User) -> bool:
+        """Check if user matches admin_groups or admin_users (OR logic)."""
+        if self.admin_groups:
+            user_groups = set(user.access_claims.get("cognito:groups", []))
+            if user_groups & self.admin_groups:
+                return True
+        if self.admin_users and user.email.lower() in self.admin_users:
+            return True
+        return False
 
     def is_authorised(self, user: User) -> bool:
         """Check if user is authorised"""
@@ -120,6 +140,14 @@ class Authoriser:
         if not user.is_authenticated:
             logger.warning("User not authenticated, denying access")
             return False
+
+        # App admins bypass access rules
+        if self._is_app_admin(user):
+            user.is_app_admin = True
+            logger.info(
+                "User is app admin, granting access: email=%s", user.email
+            )
+            return True
 
         if not self.rules:
             logger.debug("No rules configured, allowing all authenticated users")
@@ -150,6 +178,8 @@ class Authoriser:
         allowed_groups: list[str] | None = None,
         allowed_users: list[str] | None = None,
         require_all: bool = False,
+        admin_groups: list[str] | None = None,
+        admin_users: list[str] | None = None,
     ) -> "Authoriser":
         """
         Create an Authoriser from simple lists of allowed values.
@@ -158,6 +188,8 @@ class Authoriser:
             allowed_groups: List of allowed Cognito groups
             allowed_users: List of allowed email addresses
             require_all: If True, ALL rules must pass. If False, ANY rule passes.
+            admin_groups: Cognito groups that grant app-admin status
+            admin_users: Email addresses that grant app-admin status
 
         Returns:
             Authoriser instance with the specified rules
@@ -170,7 +202,12 @@ class Authoriser:
         if allowed_users:
             rules.append(EmailRule(set(allowed_users)))
 
-        return cls(rules, require_all=require_all)
+        return cls(
+            rules,
+            require_all=require_all,
+            admin_groups=set(admin_groups) if admin_groups else None,
+            admin_users=set(admin_users) if admin_users else None,
+        )
 
     @classmethod
     @cached(cache=_config_cache)
@@ -240,16 +277,20 @@ class Authoriser:
 
         logger.info(
             "Authoriser config loaded: allowed_groups=%s, "
-            "allowed_users=%s, require_all=%s",
+            "allowed_users=%s, require_all=%s, admin_groups=%s, admin_users=%s",
             config.allowed_groups,
             len(config.allowed_users) if config.allowed_users else 0,
             config.require_all,
+            config.admin_groups,
+            len(config.admin_users) if config.admin_users else 0,
         )
 
         return cls.from_lists(
             allowed_groups=config.allowed_groups,
             allowed_users=config.allowed_users,
             require_all=config.require_all,
+            admin_groups=config.admin_groups,
+            admin_users=config.admin_users,
         )
 
     @staticmethod

--- a/src/cognito_auth/authoriser.py
+++ b/src/cognito_auth/authoriser.py
@@ -147,6 +147,11 @@ class Authoriser:
             logger.info("User is app admin, granting access: email=%s", user.email)
             return True
 
+        # Platform admins bypass access rules
+        if user.is_gds_idea:
+            logger.info("User is platform admin, granting access: email=%s", user.email)
+            return True
+
         if not self.rules:
             logger.debug("No rules configured, allowing all authenticated users")
             return True  # No rules = allow all authenticated users

--- a/src/cognito_auth/user.py
+++ b/src/cognito_auth/user.py
@@ -69,6 +69,7 @@ class User:
             self._access_claims = jwt.get_unverified_claims(access_token_header)
 
         self._is_authenticated = True
+        self._is_app_admin = False
 
         logger.info(
             "User authenticated: email=%s, groups=%s, sub=%s",
@@ -128,9 +129,23 @@ class User:
         return group in self.groups
 
     @property
-    def is_admin(self) -> bool:
-        """Whether the user is an admin (member of gds-idea group)"""
+    def is_gds_idea(self) -> bool:
+        """Platform-level admin: member of gds-idea group."""
         return "gds-idea" in self.groups
+
+    @property
+    def is_app_admin(self) -> bool:
+        """App-level admin: set by Authoriser from admin_groups/admin_users config."""
+        return self._is_app_admin
+
+    @is_app_admin.setter
+    def is_app_admin(self, value: bool) -> None:
+        self._is_app_admin = value
+
+    @property
+    def is_admin(self) -> bool:
+        """Whether the user has admin privileges (platform or app-level)."""
+        return self.is_gds_idea or self.is_app_admin
 
     @property
     def email_verified(self) -> bool:
@@ -276,6 +291,7 @@ class User:
         instance._oidc_claims = oidc_claims
         instance._access_claims = access_claims
         instance._is_authenticated = True
+        instance._is_app_admin = False
 
         logger.info(
             "Mock user created: name=%s, email=%s, groups=%s, sub=%s",

--- a/src/cognito_auth/user.py
+++ b/src/cognito_auth/user.py
@@ -123,6 +123,10 @@ class User:
         """User's Cognito groups"""
         return self._access_claims.get("cognito:groups", [])
 
+    def is_in(self, group: str) -> bool:
+        """Whether the user belongs to the given Cognito group."""
+        return group in self.groups
+
     @property
     def is_admin(self) -> bool:
         """Whether the user is an admin (member of gds-idea group)"""

--- a/tests/cognito_auth/test_authoriser.py
+++ b/tests/cognito_auth/test_authoriser.py
@@ -472,6 +472,24 @@ def test_authoriser_unauthenticated_admin_denied(suppress_warnings):
     assert authoriser.is_authorised(user) is False
 
 
+def test_authoriser_gds_idea_bypasses_rules(suppress_warnings):
+    """Platform admin (gds-idea) bypasses access rules without being listed"""
+    user = User.create_mock(email="platform@example.com", groups=["gds-idea"])
+    authoriser = Authoriser.from_lists(allowed_groups=["co", "hmrc"])
+    # gds-idea is not in allowed_groups, but user bypasses rules
+    assert authoriser.is_authorised(user) is True
+    assert user.is_gds_idea is True
+    assert user.is_app_admin is False
+
+
+def test_authoriser_gds_idea_unauthenticated_denied(suppress_warnings):
+    """Unauthenticated gds-idea user is still denied"""
+    user = User.create_mock(email="platform@example.com", groups=["gds-idea"])
+    user._is_authenticated = False
+    authoriser = Authoriser.from_lists(allowed_groups=["co"])
+    assert authoriser.is_authorised(user) is False
+
+
 # Tests for Authoriser.from_config()
 
 

--- a/tests/cognito_auth/test_authoriser.py
+++ b/tests/cognito_auth/test_authoriser.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from cognito_auth import Authoriser, User
-from cognito_auth.authoriser import EmailRule, GroupRule
+from cognito_auth.authoriser import AuthConfig, EmailRule, GroupRule
 
 
 @pytest.fixture
@@ -338,6 +338,49 @@ def test_authoriser_denies_unauthenticated_user(suppress_warnings):
 
     authoriser = Authoriser.from_lists(allowed_groups=["developers"])
     assert authoriser.is_authorised(user) is False
+
+
+# Tests for AuthConfig admin fields
+
+
+def test_auth_config_accepts_admin_groups():
+    """AuthConfig accepts admin_groups field"""
+    config = AuthConfig(
+        allowed_groups=["developers"],
+        admin_groups=["dsit"],
+    )
+    assert config.admin_groups == ["dsit"]
+
+
+def test_auth_config_accepts_admin_users():
+    """AuthConfig accepts admin_users with valid emails"""
+    config = AuthConfig(
+        allowed_groups=["developers"],
+        admin_users=["alice@cabinetoffice.gov.uk"],
+    )
+    assert config.admin_users == ["alice@cabinetoffice.gov.uk"]
+
+
+def test_auth_config_admin_users_validates_emails():
+    """AuthConfig validates admin_users as email addresses"""
+    with pytest.raises(Exception, match="email"):
+        AuthConfig(
+            allowed_groups=["developers"],
+            admin_users=["not-an-email"],
+        )
+
+
+def test_auth_config_admin_fields_default_none():
+    """AuthConfig admin fields default to None"""
+    config = AuthConfig(allowed_groups=["developers"])
+    assert config.admin_groups is None
+    assert config.admin_users is None
+
+
+def test_auth_config_still_requires_access_rules():
+    """AuthConfig still requires allowed_groups or allowed_users even with admin fields"""
+    with pytest.raises(ValueError, match="at least one of"):
+        AuthConfig(admin_groups=["dsit"])
 
 
 # Tests for Authoriser.from_config()

--- a/tests/cognito_auth/test_authoriser.py
+++ b/tests/cognito_auth/test_authoriser.py
@@ -378,7 +378,7 @@ def test_auth_config_admin_fields_default_none():
 
 
 def test_auth_config_still_requires_access_rules():
-    """AuthConfig still requires allowed_groups or allowed_users even with admin fields"""
+    """AuthConfig requires allowed_groups or allowed_users even with admin fields"""
     with pytest.raises(ValueError, match="at least one of"):
         AuthConfig(admin_groups=["dsit"])
 

--- a/tests/cognito_auth/test_authoriser.py
+++ b/tests/cognito_auth/test_authoriser.py
@@ -383,6 +383,95 @@ def test_auth_config_still_requires_access_rules():
         AuthConfig(admin_groups=["dsit"])
 
 
+# Tests for Authoriser app-admin support
+
+
+def test_authoriser_admin_by_group_bypasses_rules(suppress_warnings):
+    """User in admin_groups is authorised and marked as app admin"""
+    user = User.create_mock(email="alice@example.com", groups=["dsit"])
+    authoriser = Authoriser.from_lists(
+        allowed_groups=["co"],
+        admin_groups=["dsit"],
+    )
+    assert authoriser.is_authorised(user) is True
+    assert user.is_app_admin is True
+
+
+def test_authoriser_admin_by_email_bypasses_rules(suppress_warnings):
+    """User in admin_users is authorised and marked as app admin"""
+    user = User.create_mock(email="alice@cabinetoffice.gov.uk", groups=[])
+    authoriser = Authoriser.from_lists(
+        allowed_groups=["co"],
+        admin_users=["alice@cabinetoffice.gov.uk"],
+    )
+    assert authoriser.is_authorised(user) is True
+    assert user.is_app_admin is True
+
+
+def test_authoriser_admin_email_case_insensitive(suppress_warnings):
+    """Admin email matching is case-insensitive"""
+    user = User.create_mock(email="Alice@CabinetOffice.gov.uk", groups=[])
+    authoriser = Authoriser.from_lists(
+        allowed_groups=["co"],
+        admin_users=["alice@cabinetoffice.gov.uk"],
+    )
+    assert authoriser.is_authorised(user) is True
+    assert user.is_app_admin is True
+
+
+def test_authoriser_non_admin_evaluated_normally(suppress_warnings):
+    """Non-admin user is evaluated against normal rules"""
+    user = User.create_mock(email="bob@example.com", groups=["co"])
+    authoriser = Authoriser.from_lists(
+        allowed_groups=["co"],
+        admin_groups=["dsit"],
+    )
+    assert authoriser.is_authorised(user) is True
+    assert user.is_app_admin is False
+
+
+def test_authoriser_non_admin_denied_by_rules(suppress_warnings):
+    """Non-admin user denied when rules don't match"""
+    user = User.create_mock(email="bob@example.com", groups=["hmrc"])
+    authoriser = Authoriser.from_lists(
+        allowed_groups=["co"],
+        admin_groups=["dsit"],
+    )
+    assert authoriser.is_authorised(user) is False
+    assert user.is_app_admin is False
+
+
+def test_authoriser_admin_not_in_allowed_groups_still_passes(suppress_warnings):
+    """Admin user passes even if not in allowed_groups"""
+    user = User.create_mock(email="alice@example.com", groups=["dsit"])
+    authoriser = Authoriser.from_lists(
+        allowed_groups=["co", "hmrc"],
+        admin_groups=["dsit"],
+    )
+    # dsit is not in allowed_groups, but user is an admin
+    assert authoriser.is_authorised(user) is True
+    assert user.is_app_admin is True
+
+
+def test_authoriser_no_admin_config_works_normally(suppress_warnings):
+    """Authoriser without admin config works as before"""
+    user = User.create_mock(email="bob@example.com", groups=["co"])
+    authoriser = Authoriser.from_lists(allowed_groups=["co"])
+    assert authoriser.is_authorised(user) is True
+    assert user.is_app_admin is False
+
+
+def test_authoriser_unauthenticated_admin_denied(suppress_warnings):
+    """Unauthenticated user denied even if in admin_groups"""
+    user = User.create_mock(email="alice@example.com", groups=["dsit"])
+    user._is_authenticated = False
+    authoriser = Authoriser.from_lists(
+        allowed_groups=["co"],
+        admin_groups=["dsit"],
+    )
+    assert authoriser.is_authorised(user) is False
+
+
 # Tests for Authoriser.from_config()
 
 
@@ -522,10 +611,38 @@ def test_from_config_respects_require_all(tmp_path):
             }
         )
     )
-
     with patch.dict(os.environ, {"COGNITO_AUTH_CONFIG_PATH": str(config_file)}):
         authoriser = Authoriser.from_config()
         assert authoriser.require_all is True
+
+
+def test_from_config_loads_admin_fields(tmp_path, suppress_warnings):
+    """from_config loads admin_groups and admin_users from file"""
+    config_file = tmp_path / "auth-config.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "allowed_groups": ["co", "hmrc"],
+                "admin_groups": ["dsit"],
+                "admin_users": ["alice@cabinetoffice.gov.uk"],
+            }
+        )
+    )
+
+    with patch.dict(os.environ, {"COGNITO_AUTH_CONFIG_PATH": str(config_file)}):
+        authoriser = Authoriser.from_config()
+        assert authoriser.admin_groups == {"dsit"}
+        assert authoriser.admin_users == {"alice@cabinetoffice.gov.uk"}
+
+        # Verify admin bypass works end-to-end
+        admin_user = User.create_mock(email="alice@cabinetoffice.gov.uk", groups=[])
+        assert authoriser.is_authorised(admin_user) is True
+        assert admin_user.is_app_admin is True
+
+        # Verify normal user still evaluated by rules
+        normal_user = User.create_mock(email="bob@example.com", groups=["co"])
+        assert authoriser.is_authorised(normal_user) is True
+        assert normal_user.is_app_admin is False
 
 
 # Tests for TTL caching

--- a/tests/cognito_auth/test_user.py
+++ b/tests/cognito_auth/test_user.py
@@ -214,6 +214,38 @@ def test_user_is_admin_empty_groups(suppress_warnings):
     assert user.is_admin is False
 
 
+def test_user_is_admin_true_for_app_admin(suppress_warnings):
+    """is_admin returns True when user is an app admin"""
+    user = User.create_mock(groups=["dsit"])
+    user.is_app_admin = True
+    assert user.is_admin is True
+
+
+def test_user_is_gds_idea_true(suppress_warnings):
+    """is_gds_idea returns True when user is in gds-idea group"""
+    user = User.create_mock(groups=["gds-idea", "users"])
+    assert user.is_gds_idea is True
+
+
+def test_user_is_gds_idea_false(suppress_warnings):
+    """is_gds_idea returns False when user is not in gds-idea group"""
+    user = User.create_mock(groups=["developers"])
+    assert user.is_gds_idea is False
+
+
+def test_user_is_app_admin_defaults_false(suppress_warnings):
+    """is_app_admin defaults to False"""
+    user = User.create_mock(groups=["developers"])
+    assert user.is_app_admin is False
+
+
+def test_user_is_app_admin_settable(suppress_warnings):
+    """is_app_admin can be set to True"""
+    user = User.create_mock(groups=["developers"])
+    user.is_app_admin = True
+    assert user.is_app_admin is True
+
+
 def test_user_exp_in_future(suppress_warnings):
     """Expiration is in the future"""
     user = User.create_mock()

--- a/tests/cognito_auth/test_user.py
+++ b/tests/cognito_auth/test_user.py
@@ -178,6 +178,24 @@ def test_user_groups_populated(suppress_warnings):
     assert user.groups == ["admin", "users", "developers"]
 
 
+def test_user_is_in_returns_true(suppress_warnings):
+    """is_in returns True when user belongs to group"""
+    user = User.create_mock(groups=["developers", "users"])
+    assert user.is_in("developers") is True
+
+
+def test_user_is_in_returns_false(suppress_warnings):
+    """is_in returns False when user does not belong to group"""
+    user = User.create_mock(groups=["developers", "users"])
+    assert user.is_in("admins") is False
+
+
+def test_user_is_in_empty_groups(suppress_warnings):
+    """is_in returns False when user has no groups"""
+    user = User.create_mock(groups=[])
+    assert user.is_in("developers") is False
+
+
 def test_user_is_admin_true(suppress_warnings):
     """is_admin returns True when user is in gds-idea group"""
     user = User.create_mock(groups=["gds-idea", "users"])

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ wheels = [
 
 [[package]]
 name = "cognito-auth"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -329,11 +329,15 @@ all = [
     { name = "fastapi" },
     { name = "flask" },
     { name = "gradio" },
+    { name = "pandas" },
     { name = "streamlit" },
 ]
 dash = [
     { name = "dash" },
     { name = "flask" },
+]
+df = [
+    { name = "pandas" },
 ]
 fastapi = [
     { name = "fastapi" },
@@ -350,6 +354,7 @@ dev = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pandas" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -367,6 +372,8 @@ requires-dist = [
     { name = "flask", marker = "extra == 'dash'", specifier = ">=2.0.0" },
     { name = "gradio", marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "gradio", marker = "extra == 'gradio'", specifier = ">=4.0.0" },
+    { name = "pandas", marker = "extra == 'all'", specifier = ">=2.2.0" },
+    { name = "pandas", marker = "extra == 'df'", specifier = ">=2.2.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.0.0" },
     { name = "python-jose", specifier = ">=3.5.0" },
     { name = "requests", specifier = ">=2.32.5" },
@@ -379,6 +386,7 @@ dev = [
     { name = "mkdocs", specifier = ">=1.6.0" },
     { name = "mkdocs-material", specifier = ">=9.5.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26.0" },
+    { name = "pandas", specifier = ">=2.2.0" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.13.3" },


### PR DESCRIPTION
## Summary

- Adds `admin_groups` and `admin_users` config fields for app-level admin designation
- App admins are implicitly authorised (bypass access rules) and see all data via `AuthorisedDataFrame`
- Platform admins (`gds-idea` group) now implicitly bypass all app authorisers — no longer need to be listed in every app's `allowed_groups`
- Adds `User.is_in(group)` helper for readable group membership checks
- Broadens `User.is_admin` to cover both platform (`is_gds_idea`) and app-level (`is_app_admin`) admins

## Changes

### `User` model
- `is_in(group)` — returns `True` if user belongs to the given Cognito group
- `is_gds_idea` — property for platform-level admin check
- `is_app_admin` — writable property, set by `Authoriser` when admin match found
- `is_admin` — now returns `is_gds_idea or is_app_admin` (breaking: previously only checked `gds-idea` group)

### `AuthConfig`
- `admin_groups: list[str] | None` — Cognito groups that grant app-admin status
- `admin_users: list[str] | None` — email addresses that grant app-admin status
- Email validation reused for both `allowed_users` and `admin_users`
- Access rules (`allowed_groups`/`allowed_users`) still required

### `Authoriser`
- `is_authorised()` checks admin match first (OR logic across groups and emails), sets `user.is_app_admin = True`, returns `True` without evaluating access rules
- Platform admins (`gds-idea`) also bypass access rules implicitly
- Unauthenticated users still denied regardless of admin status

## Backwards compatibility

- `AuthConfig` uses Pydantic v2 default `extra="ignore"` — older library versions silently ignore the new fields in config
- `is_admin` semantics broadened — previously only `gds-idea` group, now includes app admins. This is the intended behaviour but is technically breaking.

## Tests

22 new tests covering all new functionality. 135 core tests passing.

Closes #47