### PR TITLE
feat: add ThrottledLogger to reduce per-request log noise

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,2 @@
+# Pre-existing mock JWT token in test fixtures (not a real secret)
+6b4e33222c23748e1b25e8e031eb1292b60d9dbf:tests/cognito_auth/test_lambda_auth.py:generic-api-key:138

--- a/src/cognito_auth/_logging.py
+++ b/src/cognito_auth/_logging.py
@@ -1,0 +1,60 @@
+"""
+Throttled logging utilities for cognito-auth.
+
+Reduces log noise by emitting INFO only on first-seen per user within a
+TTL window, then DEBUG for subsequent occurrences.
+"""
+
+import logging
+import os
+
+from cachetools import TTLCache
+
+_DEFAULT_TTL = 300  # 5 minutes
+
+
+class ThrottledLogger:
+    """
+    Logger wrapper that emits INFO only on first-seen per user within
+    a TTL window, then DEBUG for subsequent occurrences.
+
+    Each instance maintains its own cache, so modules are naturally isolated.
+
+    Args:
+        logger: The underlying Python logger to delegate to.
+        ttl: Cache TTL in seconds. Defaults to COGNITO_AUTH_LOG_TTL env var
+            or 300 seconds (5 minutes).
+        maxsize: Maximum number of user keys to track. Defaults to 1024.
+
+    Example:
+        >>> import logging
+        >>> logger = logging.getLogger(__name__)
+        >>> _throttled = ThrottledLogger(logger)
+        >>> _throttled.info(user.sub, "User authenticated: email=%s", user.email)
+    """
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        ttl: int | None = None,
+        maxsize: int = 1024,
+    ):
+        self._logger = logger
+        _ttl = ttl or int(os.getenv("COGNITO_AUTH_LOG_TTL", _DEFAULT_TTL))
+        self._cache: TTLCache = TTLCache(maxsize=maxsize, ttl=_ttl)
+
+    def info(self, user_key: str, msg: str, *args):
+        """
+        Log at INFO if user_key is first-seen within the TTL window,
+        otherwise log at DEBUG.
+
+        Args:
+            user_key: Unique identifier for the user (e.g., sub or email).
+            msg: Log message format string.
+            *args: Arguments for the format string.
+        """
+        if user_key not in self._cache:
+            self._cache[user_key] = True
+            self._logger.info(msg, *args)
+        else:
+            self._logger.debug(msg, *args)

--- a/src/cognito_auth/authoriser.py
+++ b/src/cognito_auth/authoriser.py
@@ -13,9 +13,11 @@ from pydantic import (
     model_validator,
 )
 
+from ._logging import ThrottledLogger
 from .user import User
 
 logger = logging.getLogger(__name__)
+_throttled = ThrottledLogger(logger)
 
 # TTL cache for config loading - 5 minutes
 _config_cache = TTLCache(maxsize=1, ttl=300)
@@ -144,12 +146,20 @@ class Authoriser:
         # App admins bypass access rules
         if self._is_app_admin(user):
             user.is_app_admin = True
-            logger.info("User is app admin, granting access: email=%s", user.email)
+            _throttled.info(
+                user.email,
+                "User is app admin, granting access: email=%s",
+                user.email,
+            )
             return True
 
         # Platform admins bypass access rules
         if user.is_gds_idea:
-            logger.info("User is platform admin, granting access: email=%s", user.email)
+            _throttled.info(
+                user.email,
+                "User is platform admin, granting access: email=%s",
+                user.email,
+            )
             return True
 
         if not self.rules:
@@ -167,7 +177,12 @@ class Authoriser:
             authorised = any(results)
 
         if authorised:
-            logger.info("User authorised: email=%s, groups=%s", user.email, user.groups)
+            _throttled.info(
+                user.email,
+                "User authorised: email=%s, groups=%s",
+                user.email,
+                user.groups,
+            )
         else:
             logger.warning(
                 "User denied access: email=%s, groups=%s", user.email, user.groups

--- a/src/cognito_auth/user.py
+++ b/src/cognito_auth/user.py
@@ -9,10 +9,12 @@ from typing import Any
 
 from jose import jwt
 
+from ._logging import ThrottledLogger
 from .exceptions import MissingTokenError
 from .token_verifier import TokenVerifier
 
 logger = logging.getLogger(__name__)
+_throttled = ThrottledLogger(logger)
 
 
 class User:
@@ -71,7 +73,8 @@ class User:
         self._is_authenticated = True
         self._is_app_admin = False
 
-        logger.info(
+        _throttled.info(
+            self._oidc_claims.get("sub", "unknown"),
             "User authenticated: email=%s, groups=%s, sub=%s",
             self._oidc_claims.get("email", "N/A"),
             self._access_claims.get("cognito:groups", []),

--- a/tests/cognito_auth/test_logging.py
+++ b/tests/cognito_auth/test_logging.py
@@ -1,0 +1,133 @@
+"""Tests for ThrottledLogger."""
+
+import logging
+
+import pytest
+
+from cognito_auth._logging import ThrottledLogger
+
+
+@pytest.fixture
+def logger():
+    """Create a test logger with a handler that captures records."""
+    test_logger = logging.getLogger("test.throttled")
+    test_logger.setLevel(logging.DEBUG)
+    test_logger.handlers.clear()
+    return test_logger
+
+
+@pytest.fixture
+def handler(logger):
+    """Attach a handler that captures log records."""
+
+    class RecordCapture(logging.Handler):
+        def __init__(self):
+            super().__init__()
+            self.records: list[logging.LogRecord] = []
+
+        def emit(self, record):
+            self.records.append(record)
+
+    capture = RecordCapture()
+    capture.setLevel(logging.DEBUG)
+    logger.addHandler(capture)
+    return capture
+
+
+class TestThrottledLogger:
+    """Tests for ThrottledLogger.info() throttling behaviour."""
+
+    def test_first_call_logs_at_info(self, logger, handler):
+        """First call for a user should log at INFO level."""
+        throttled = ThrottledLogger(logger, ttl=60)
+
+        throttled.info("user-1", "Hello %s", "world")
+
+        assert len(handler.records) == 1
+        assert handler.records[0].levelno == logging.INFO
+        assert handler.records[0].getMessage() == "Hello world"
+
+    def test_second_call_same_user_logs_at_debug(self, logger, handler):
+        """Subsequent calls for the same user should log at DEBUG."""
+        throttled = ThrottledLogger(logger, ttl=60)
+
+        throttled.info("user-1", "First call")
+        throttled.info("user-1", "Second call")
+
+        assert len(handler.records) == 2
+        assert handler.records[0].levelno == logging.INFO
+        assert handler.records[1].levelno == logging.DEBUG
+
+    def test_different_users_each_log_at_info(self, logger, handler):
+        """Different user keys should each get their own first INFO log."""
+        throttled = ThrottledLogger(logger, ttl=60)
+
+        throttled.info("user-1", "User 1 first")
+        throttled.info("user-2", "User 2 first")
+        throttled.info("user-1", "User 1 second")
+
+        assert len(handler.records) == 3
+        assert handler.records[0].levelno == logging.INFO
+        assert handler.records[1].levelno == logging.INFO
+        assert handler.records[2].levelno == logging.DEBUG
+
+    def test_separate_instances_are_independent(self, logger, handler):
+        """Two ThrottledLogger instances should track users independently."""
+        throttled_a = ThrottledLogger(logger, ttl=60)
+        throttled_b = ThrottledLogger(logger, ttl=60)
+
+        throttled_a.info("user-1", "Instance A first")
+        throttled_b.info("user-1", "Instance B first")
+
+        assert len(handler.records) == 2
+        assert handler.records[0].levelno == logging.INFO
+        assert handler.records[1].levelno == logging.INFO
+
+    def test_ttl_expiry_resets_to_info(self, logger, handler):
+        """After TTL expires, user should log at INFO again."""
+        throttled = ThrottledLogger(logger, ttl=1)
+
+        throttled.info("user-1", "First call")
+        assert handler.records[0].levelno == logging.INFO
+
+        throttled.info("user-1", "Second call (cached)")
+        assert handler.records[1].levelno == logging.DEBUG
+
+        # Manually expire the cache to simulate TTL expiry
+        throttled._cache.clear()
+
+        throttled.info("user-1", "After expiry")
+        assert handler.records[2].levelno == logging.INFO
+
+    def test_format_args_are_passed_correctly(self, logger, handler):
+        """Format arguments should be passed through to the logger."""
+        throttled = ThrottledLogger(logger, ttl=60)
+
+        throttled.info("user-1", "email=%s, groups=%s", "a@b.com", ["admin"])
+
+        assert handler.records[0].getMessage() == "email=a@b.com, groups=['admin']"
+
+    def test_maxsize_evicts_oldest(self, logger, handler):
+        """When maxsize is exceeded, oldest entries should be evicted."""
+        throttled = ThrottledLogger(logger, ttl=60, maxsize=2)
+
+        throttled.info("user-1", "User 1 first")
+        throttled.info("user-2", "User 2 first")
+        throttled.info("user-3", "User 3 first")  # evicts user-1
+
+        # user-1 was evicted, so should log at INFO again
+        throttled.info("user-1", "User 1 again")
+
+        assert handler.records[0].levelno == logging.INFO  # user-1 first
+        assert handler.records[1].levelno == logging.INFO  # user-2 first
+        assert handler.records[2].levelno == logging.INFO  # user-3 first
+        assert handler.records[3].levelno == logging.INFO  # user-1 re-seen
+
+    def test_env_var_overrides_default_ttl(self, monkeypatch, logger, handler):
+        """COGNITO_AUTH_LOG_TTL env var should override the default TTL."""
+        monkeypatch.setenv("COGNITO_AUTH_LOG_TTL", "120")
+
+        throttled = ThrottledLogger(logger)
+
+        # Verify cache was created with env var TTL
+        assert throttled._cache.ttl == 120


### PR DESCRIPTION
## Summary

Reduces repetitive per-request log noise by introducing a `ThrottledLogger` class that emits `INFO` only on first-seen per user within a TTL window, then `DEBUG` for subsequent requests from the same user.

## Problem

Every authenticated request produced multiple INFO lines:
- `User authenticated: email=...`
- `User is platform admin, granting access: email=...`

For active apps this creates huge volumes of repetitive logs with no additional signal.

## Solution

`ThrottledLogger` - a lightweight wrapper around Python's logger that uses a per-instance `TTLCache` (keyed by user identifier) to deduplicate:

- **First request** from a user within the 5-minute window: logs at `INFO`
- **Subsequent requests** from the same user: logs at `DEBUG`
- **Access denied / errors**: always fire at `WARNING`/`ERROR` (unchanged)

Each module (`user.py`, `authoriser.py`) gets its own `ThrottledLogger` instance with an independent cache.

## Configuration

| Env var | Effect |
|---------|--------|
| `COGNITO_AUTH_LOG_TTL=60` | Reduce window to 1 minute |
| `COGNITO_AUTH_LOG_TTL=3600` | Increase to 1 hour |
| Not set | Default 5 minutes (300s) |

## Changes

- **New**: `src/cognito_auth/_logging.py` — `ThrottledLogger` class
- **Modified**: `src/cognito_auth/user.py` — throttle `User authenticated` log
- **Modified**: `src/cognito_auth/authoriser.py` — throttle admin/authorised logs
- **New**: `tests/cognito_auth/test_logging.py` — 8 tests covering throttle behaviour
- **New**: `.gitleaksignore` — suppress pre-existing false positive on test mock JWT

## Testing

All 151 existing tests pass, plus 8 new tests for ThrottledLogger.