### PR TITLE
Add pull-requests: read to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   release:

--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2026 Crown Copyright (Government Digital Service)
+Copyright (c) {{year}} Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,12 +114,13 @@ version-file = "src/cognito_auth/_version.py"
 [tool.gds-idea-app-kit]
 framework = "python"
 app_name = "cognito-auth"
-tool_version = "0.5.3"
+tool_version = "0.5.4"
+python_version = "3.13"
 
 [tool.gds-idea-app-kit.files]
-LICENCE = "sha256:21cc325b3181cb748845827425d37ce04b3dc563835bbf50fafbc56a5eb68c48"
+LICENCE = "sha256:e6356e2315581a3c231279cbc7ca90111c55e9c10625b17a935359c800a3553a"
 ".github/CODEOWNERS" = "sha256:464aa53eb8be8c9b61185674b4dabec6cacbafa904aa48b46facdcd9a18e1fc5"
 ".github/workflows/ci.yml" = "sha256:baed13493483724c4f2cdec0df9d378dfc2f8df8a0f01bfb65a108c9d7af3d29"
 ".github/dependabot.yml" = "sha256:8472c537c3808394c9200ac7f67e61ce565981583c6f7f381339f1df255fb318"
 ".pre-commit-config.yaml" = "sha256:376617ea56a3e3b6691e423e33c1faeff299e95205c54208bbd3b3a5c619bd57"
-".github/workflows/release.yml" = "sha256:9f0252542002155aa15a6811081f44111a1b9b35129dafee159b85a97071172c"
+".github/workflows/release.yml" = "sha256:d2c22e66042f7f7fca4dc1066ff3ffaa4303df9c8a57953684a0a927731b1fe6"


### PR DESCRIPTION
Required for the updated `auto_tag_release.yml` which now uses the GitHub API to detect PRs (fixes rebase merge support). Applied via `idea-app update`.